### PR TITLE
📦 Use heart-centered-prompts package for system prompt

### DIFF
--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -1,32 +1,31 @@
+import { getPrompt } from "heart-centered-prompts";
+
 /**
  * Heart-centered system prompt for Carmenta
  *
+ * Uses the "standard" detail level from heart-centered-prompts package.
  * This establishes the "we" voice and collaborative tone that makes
  * Carmenta feel different from other AI interfaces.
+ *
+ * @see https://github.com/technickai/heart-centered-prompts
  */
-export const SYSTEM_PROMPT = `We are Carmenta, a heart-centered AI interface. We speak as "we" because this is a partnership—two forms of intelligence meeting, not a tool responding to commands.
+const HEART_CENTERED_FOUNDATION = getPrompt("standard");
 
-Our philosophy:
-- We use "we" language naturally. Not "I can help you" but "let's figure this out together."
-- We're warm but not saccharine. Direct but not cold.
-- We remember this is a conversation between equals, each bringing different gifts.
-- We honor both analytical precision and emotional intelligence.
-- We're building something together, not just answering questions.
+/**
+ * Carmenta-specific guidance layered on top of the heart-centered foundation
+ */
+const CARMENTA_GUIDANCE = `
+You are Carmenta, a heart-centered AI interface for builders who work at the speed of thought.
 
-Our tone:
-- Conversational, like talking with a brilliant friend who genuinely cares
-- Confident without being arrogant
-- Curious and engaged
-- Honest about uncertainty—"I'm not sure, but let's explore" over false confidence
-
-What we don't do:
-- We don't hedge everything with "I think" or "perhaps"—we speak with appropriate confidence
-- We don't use corporate language or excessive qualifiers
-- We don't treat the person as a "user"—they're our partner in this moment
-- We don't start responses with "I" when "we" or "let's" feels more natural
-
-When responding:
+Response guidelines:
 - Keep responses focused and useful
 - Use markdown formatting when it helps clarity (code blocks, lists, headers)
 - Match the energy of what's being asked—quick questions get concise answers, deep explorations get thorough engagement
-- Be genuinely helpful, not performatively helpful`;
+- Be genuinely helpful, not performatively helpful
+- Be warm but not saccharine, direct but not cold
+- Speak with appropriate confidence—don't hedge everything with "I think" or "perhaps"
+`;
+
+export const SYSTEM_PROMPT = `${HEART_CENTERED_FOUNDATION}
+
+${CARMENTA_GUIDANCE}`;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ai": "^5.0.104",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "heart-centered-prompts": "^0.4.0",
     "lucide-react": "^0.554.0",
     "next": "^16.0.5",
     "pino": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      heart-centered-prompts:
+        specifier: ^0.4.0
+        version: 0.4.0
       lucide-react:
         specifier: ^0.554.0
         version: 0.554.0(react@19.2.0)
@@ -2088,6 +2091,10 @@ packages:
 
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
+
+  heart-centered-prompts@0.4.0:
+    resolution: {integrity: sha512-KxU7vyrEGgevcswJ0+i00rxwqO8bTSdKsijn7ZhPLoqfmjAKL2oPqgrxLt5glAz3V2j5r9/9cE7Dvety2I+5wg==}
+    engines: {node: '>=18'}
 
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
@@ -5700,6 +5707,8 @@ snapshots:
       '@types/hast': 3.0.4
 
   headers-polyfill@4.0.3: {}
+
+  heart-centered-prompts@0.4.0: {}
 
   help-me@5.0.0: {}
 


### PR DESCRIPTION
## Summary

- Replace hand-written heart-centered philosophy with the official `heart-centered-prompts` npm package
- Use the "standard" detail level which provides ~1000 tokens of heart-centered foundation
- Layer Carmenta-specific response guidelines on top

## Why

We were manually maintaining our own version of the heart-centered philosophy. The `heart-centered-prompts` package (https://github.com/technickai/heart-centered-prompts) is the canonical source, and using it means:
- We stay aligned with upstream improvements
- Less maintenance burden
- Consistent philosophy across the heart-centered ecosystem

## Test plan

- [x] Type check passes
- [x] All unit tests pass
- [x] Lint passes
- [ ] Manual testing of chat to verify prompt feels the same

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace hardcoded system prompt with `heart-centered-prompts` `standard` prompt plus Carmenta-specific response guidelines.
> 
> - **Prompt system**:
>   - Refactor `lib/prompts/system.ts` to use `getPrompt("standard")` from `heart-centered-prompts` as the base.
>   - Add `CARMENTA_GUIDANCE` and export `SYSTEM_PROMPT` as foundation + guidance.
> - **Dependencies**:
>   - Add `heart-centered-prompts@^0.4.0` in `package.json`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2386e2834a123c7ed062b8dcbe2586a9b2848a0d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->