### PR TITLE
🩹 Handle failed page extractions gracefully

### DIFF
--- a/app/api/connect/route.ts
+++ b/app/api/connect/route.ts
@@ -132,7 +132,7 @@ const tools = {
 
     fetchPage: tool({
         description:
-            "Fetch and extract the main content from a web page. Returns clean, readable text without ads or navigation. Use when you have a specific URL to read.",
+            "Fetch and extract the main content from a web page. Returns clean, readable text without ads or navigation. Use when you have a specific URL to read. If warning is present, the extraction was partial - inform the user and work with other sources.",
         inputSchema: z.object({
             url: z.string().url().describe("The URL to fetch content from."),
             maxLength: z
@@ -154,6 +154,18 @@ const tools = {
                     title: "",
                     content: "",
                     url,
+                };
+            }
+
+            // Surface warnings about partial/problematic extractions
+            // so the AI can respond appropriately to the user
+            if (result.warning) {
+                return {
+                    error: false,
+                    warning: result.warning,
+                    title: result.title,
+                    content: result.content,
+                    url: result.url,
                 };
             }
 

--- a/lib/web-intelligence/types.ts
+++ b/lib/web-intelligence/types.ts
@@ -38,6 +38,11 @@ export interface ExtractResponse {
     url: string;
     provider: string;
     latencyMs: number;
+    /**
+     * Optional warning when extraction completed but with issues.
+     * Examples: content too short, page blocked, JavaScript-heavy site.
+     */
+    warning?: string;
 }
 
 // Research types


### PR DESCRIPTION
## Summary

- Adds a `warning` field to `ExtractResponse` to communicate partial/problematic extractions
- Detects when page extraction returns suspiciously short content (<100 chars)
- Surfaces warnings in the `fetchPage` tool so the AI can respond appropriately
- Added tests for the new warning behavior

## Problem

When fetching a page that returns minimal content (e.g., blocked, JavaScript-heavy, or requiring auth), the stream would die silently. The user saw an incomplete response with no explanation.

**Logs showed:**
```
"url":"https://musashinoatx.com/menu","contentLength":9,"latencyMs":33389
```

The extraction "succeeded" but only returned 9 characters, causing the AI to stop mid-response.

## Solution

Now when content is < 100 chars, we:
1. Add a warning to the response explaining the issue
2. Surface it to the AI through the tool response
3. AI can inform the user and fall back to other sources gracefully

## Test plan

- [x] Unit tests pass for new warning behavior
- [x] Existing tests updated to use meaningful content length
- [x] Type-check passes
- [x] Format-check passes
- [ ] Manual test with a known problematic URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a warning when extracted page content is suspiciously short (<100 chars) and surfaces it via the fetchPage tool; updates types, logging, and tests.
> 
> - **Web Intelligence (ParallelProvider)**
>   - Add `MIN_MEANINGFUL_CONTENT_LENGTH = 100` and set `warning` when extracted `content` is below threshold; log as warn, otherwise info.
>   - Preserve truncation behavior for long content.
>   - Return `warning` in `ExtractResponse`.
> - **Types**
>   - Extend `ExtractResponse` with optional `warning?: string`.
> - **API (`app/api/connect/route.ts`)**
>   - Update `fetchPage` tool description and execution to propagate `result.warning` to callers alongside `title`, `content`, and `url`.
> - **Tests**
>   - Update extract success test to use >100-char content and assert no warning.
>   - Add tests for short-content warning and for no warning when over threshold.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ecbd2cee249a06453db0b3076f0087503de2e2bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->