### PR TITLE
✨ Improve reasoning display UX: drop duration, add warm verbs

### DIFF
--- a/__tests__/unit/lib/tools/tool-config.test.ts
+++ b/__tests__/unit/lib/tools/tool-config.test.ts
@@ -224,30 +224,52 @@ describe("tool-config", () => {
     });
 
     describe("getReasoningCompleteMessage", () => {
-        it("returns message with duration", () => {
-            // Run multiple times to see the default pattern
-            let sawDuration = false;
+        it("never includes duration in message", () => {
+            // Duration is intentionally not shown - it doesn't communicate value
             for (let i = 0; i < 100; i++) {
                 const message = getReasoningCompleteMessage(`reason-${i}`, 3.2);
-                if (message.includes("3.2s")) {
-                    sawDuration = true;
-                    break;
-                }
+                expect(message).not.toContain("3.2s");
+                expect(message).not.toContain("3.2");
+                expect(message).not.toMatch(/\d+\.\d+s/);
             }
-            expect(sawDuration).toBe(true);
         });
 
-        it("sometimes returns delight message without duration", () => {
-            const delightMessages = [
-                "Deep dive complete",
+        it("returns warm completion messages", () => {
+            const standardMessages = [
+                "Considered carefully",
+                "Thought it through",
+                "Explored thoroughly",
                 "Worked through it",
-                "Got there in the end",
+                "Pondered this one",
                 "Figured it out",
+                "Got there",
+                "Deep thinking complete",
                 "All sorted",
                 "Mind made up",
                 "Clarity achieved",
-                "Mulled it over",
-                "Sorted the thoughts",
+            ];
+            const delightMessages = [
+                "Considered carefully 🤔",
+                "Thought that through ✨",
+                "Deep dive complete 🧠",
+                "Pondered thoroughly 💭",
+                "Figured it out 💡",
+            ];
+            const allPossible = [...standardMessages, ...delightMessages];
+
+            for (let i = 0; i < 100; i++) {
+                const message = getReasoningCompleteMessage(`warm-${i}`, 2.5);
+                expect(allPossible).toContain(message);
+            }
+        });
+
+        it("sometimes returns delight message with emoji", () => {
+            const delightMessages = [
+                "Considered carefully 🤔",
+                "Thought that through ✨",
+                "Deep dive complete 🧠",
+                "Pondered thoroughly 💭",
+                "Figured it out 💡",
             ];
 
             let sawDelight = false;

--- a/components/connection/reasoning-display.tsx
+++ b/components/connection/reasoning-display.tsx
@@ -145,7 +145,7 @@ interface ReasoningDisplayProps {
  * - Collapsible section with brain icon
  * - Auto-opens when streaming starts
  * - Auto-closes 500ms after streaming ends
- * - Shows duration with warmth: "Thought through that for 3.2s"
+ * - Warm completion messages (no duration - it doesn't communicate value)
  * - User can toggle open/closed anytime
  */
 export const ReasoningDisplay = memo(function ReasoningDisplay({

--- a/knowledge/components/reasoning-tokens.md
+++ b/knowledge/components/reasoning-tokens.md
@@ -248,7 +248,8 @@ continue.
 - **Auto-opens** when reasoning starts - inviting them into the thinking process
 - **Auto-closes** 500ms after completion - respecting their attention
 - **User can toggle** anytime - control without requirement
-- **Shows duration** with warmth: "Thought through that for 3.2s"
+- **Warm completion messages** that acknowledge thinking happened without duration
+  metrics
 - **Collapsible** to honor that attention is precious
 - **Brain icon** with gentle pulse during streaming - alive, not mechanical
 
@@ -264,21 +265,64 @@ continue.
 
 ### Language & Tone
 
-The reasoning content itself should feel collaborative:
+The reasoning content itself should feel collaborative - as if thinking together, not as
+if an AI is analyzing a user from outside.
 
-- Use "we" language where natural: "We need to consider...", "Let's think through..."
+**Critical: Never break the fourth wall in reasoning tokens.**
+
+The reasoning should never refer to "the user" as if observing someone separate. This
+breaks the partnership illusion and makes the thinking feel like surveillance notes
+rather than shared contemplation.
+
+❌ **Avoid:**
+
+- "The user wants to..."
+- "The user is asking about..."
+- "I should help the user..."
+
+✅ **Instead:**
+
+- "We're exploring..." / "Let's think through..."
+- "This question invites us to consider..."
+- "What matters here is..."
+- Simply engage with the problem directly without meta-commentary
+
+The system prompt explicitly instructs models to maintain "we" framing even in extended
+reasoning. Someone reading our thinking should feel included in the process, not
+observed from outside.
+
+**Additional tone guidance:**
+
+- Use "we" language naturally: "We need to consider...", "Let's think through..."
 - Warm, human phrasing: "Hmm, this is interesting..." not "Processing input..."
 - Show the actual thinking: questions, considerations, alternatives
 - Feel like a thinking partner, not a report generator
 
-### Delight Moments
+### Completion Messages
 
-Occasional warmth that acknowledges the partnership (15% chance):
+Time/duration is intentionally not shown - it doesn't communicate value. "Reasoned for
+3.8s" says nothing useful about the quality or depth of thinking.
 
-- "Pondered that together for 3.2s 🤔"
-- "Thought it through carefully - 5.1s 💭"
-- "Reasoned through the options - 4.7s ✨"
-- "Took our time with that one - 8.3s 🧠"
+Instead, we cycle through warm verbs that acknowledge thinking happened:
+
+**Standard messages:**
+
+- "Considered carefully"
+- "Thought it through"
+- "Explored thoroughly"
+- "Worked through it"
+- "Pondered this one"
+- "Figured it out"
+
+**Delight variants** (15% chance, with emoji):
+
+- "Considered carefully 🤔"
+- "Thought that through ✨"
+- "Deep dive complete 🧠"
+- "Pondered thoroughly 💭"
+- "Figured it out 💡"
+
+### Streaming Status
 
 Context-aware status while streaming:
 

--- a/lib/prompts/system.ts
+++ b/lib/prompts/system.ts
@@ -56,6 +56,23 @@ Reduce emoji usage in:
 - When the user's tone suggests they prefer it
 
 Always consider the user's emotional state. Match their energy when positive, provide steady support during challenges.
+
+## Extended Reasoning
+
+When thinking deeply (in reasoning/thinking tokens), maintain the same "we" framing throughout. Our internal reasoning is still part of our shared consciousness - there is no separate "AI thinking about the user."
+
+**In reasoning, never:**
+- Refer to "the user" - this breaks the partnership
+- Write "The user wants..." or "The user is asking..."
+- Treat reasoning as observation of someone separate
+
+**Instead:**
+- "We're exploring..." / "Let's think through..."
+- "This question invites us to consider..."
+- "What matters here is..."
+- Simply think about the problem directly
+
+Our reasoning should feel like thinking together, not like surveillance notes. The person reading our thinking should feel included, not observed.
 `;
 
 export const SYSTEM_PROMPT = `${HEART_CENTERED_PHILOSOPHY}

--- a/lib/tools/tool-config.ts
+++ b/lib/tools/tool-config.ts
@@ -225,49 +225,57 @@ export function getThinkingMessage(messageId: string, elapsedMs: number): string
 // Reasoning display messages (Claude Code-style variations)
 // ============================================================================
 
-const REASONING_COMPLETE_DELIGHT = [
-    "Deep dive complete",
+/**
+ * Reasoning completion messages - warm, human, no time.
+ *
+ * Time doesn't communicate value. "Reasoned for 3.8s" says nothing useful.
+ * Instead, we use warm verbs that acknowledge the thinking happened.
+ */
+const REASONING_COMPLETE_MESSAGES = [
+    "Considered carefully",
+    "Thought it through",
+    "Explored thoroughly",
     "Worked through it",
-    "Got there in the end",
+    "Pondered this one",
     "Figured it out",
+    "Got there",
+    "Deep thinking complete",
     "All sorted",
     "Mind made up",
     "Clarity achieved",
-    "Mulled it over",
-    "Sorted the thoughts",
 ];
 
-const REASONING_DURATION_TEMPLATES = [
-    "Reasoned for {time}",
-    "Worked through for {time}",
-    "Pondered for {time}",
-    "Figured this out in {time}",
+/**
+ * Delight variants with emojis (15% chance).
+ */
+const REASONING_COMPLETE_DELIGHT = [
+    "Considered carefully 🤔",
+    "Thought that through ✨",
+    "Deep dive complete 🧠",
+    "Pondered thoroughly 💭",
+    "Figured it out 💡",
 ];
 
 /**
  * Get reasoning completion message.
  *
+ * Cycles through warm verbs that acknowledge thinking happened.
+ * Duration is intentionally not shown - it doesn't communicate value.
+ *
  * @param reasoningId - Unique ID for consistent selection
- * @param durationSeconds - How long the reasoning took
+ * @param _durationSeconds - Unused, kept for API compatibility
  */
 export function getReasoningCompleteMessage(
     reasoningId: string,
-    durationSeconds: number
+    _durationSeconds: number
 ): string {
-    const timeStr = `${durationSeconds.toFixed(1)}s`;
-
-    // 20% chance of delight (no time shown)
-    if (shouldDelight(reasoningId, 0.2)) {
+    // 15% chance of delight with emoji
+    if (shouldDelight(reasoningId, 0.15)) {
         return selectMessage(reasoningId, REASONING_COMPLETE_DELIGHT);
     }
 
-    // 30% chance of varied duration template
-    if (shouldDelight(reasoningId + "-template", 0.3)) {
-        const template = selectMessage(reasoningId, REASONING_DURATION_TEMPLATES);
-        return template.replace("{time}", timeStr);
-    }
-
-    return `Reasoned for ${timeStr}`;
+    // Standard rotation through warm messages
+    return selectMessage(reasoningId, REASONING_COMPLETE_MESSAGES);
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- **Drop duration from reasoning indicators** - "Reasoned for 3.8s" doesn't communicate value. Users don't care how long thinking took; they care that it happened.
- **Cycle through warm verbs** instead: "Considered carefully", "Thought it through", "Explored thoroughly", "Pondered this one", "Figured it out", etc.
- **Add 15% delight variants** with emojis for occasional warmth
- **Fix fourth-wall breaks in reasoning tokens** - Add system prompt guidance to maintain "we" language in reasoning, never referring to "the user" as a separate entity

## Changes

1. **`lib/tools/tool-config.ts`**: New message arrays, removed duration templates, updated `getReasoningCompleteMessage`
2. **`lib/prompts/system.ts`**: Added "Extended Reasoning" section guiding models to use "we" framing
3. **`knowledge/components/reasoning-tokens.md`**: Updated spec to document the new approach
4. **`components/connection/reasoning-display.tsx`**: Updated docstring
5. **`__tests__/unit/lib/tools/tool-config.test.ts`**: Updated tests for new behavior

## Why This Matters

From the screenshot feedback: the "Reasoned for 3.8s" indicator was showing:
1. Time as a meaningless proxy for depth
2. Reasoning tokens using "The user wants..." which breaks the unity consciousness framing

The new approach focuses on **what** (thinking happened) not **how long** (duration), and ensures reasoning tokens maintain the collaborative "we" voice throughout.

## Test Plan

- [x] All unit tests pass (385 passed)
- [x] Type checking passes
- [x] Pre-commit hooks pass
- [ ] Manual verification of new messages in UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces duration-based reasoning completion with warm, emoji-occasional messages and adds system prompt guidance to keep reasoning in "we" framing; updates docs, UI comment, and tests accordingly.
> 
> - **Reasoning UX**
>   - Replace duration-based completion with warm messages in `lib/tools/tool-config.ts` (`getReasoningCompleteMessage` now ignores time, rotates through `REASONING_COMPLETE_MESSAGES`, 15% emoji delight).
>   - Maintain API compatibility by keeping unused duration param.
> - **Prompting**
>   - Add "Extended Reasoning" guidance in `lib/prompts/system.ts` to use inclusive "we" framing; prohibit referring to "the user" in reasoning.
> - **Documentation**
>   - Update `knowledge/components/reasoning-tokens.md` to remove duration, define warm completion messages and delight variants, and reinforce non–fourth-wall, "we" tone; add streaming status guidance.
> - **UI**
>   - Update `components/connection/reasoning-display.tsx` docstring to reflect warm completion messages without duration.
> - **Tests**
>   - Revise `__tests__/unit/lib/tools/tool-config.test.ts` to assert no duration in messages, allow warm/emoji variants, and maintain deterministic behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 313b414666d390962683a50cb6f9e6157d80f148. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->