### PR TITLE
🐛 Fix message persistence when navigating between connections

### DIFF
--- a/lib/db/message-mapping.ts
+++ b/lib/db/message-mapping.ts
@@ -354,6 +354,7 @@ export function mapDBMessageToUI(messageWithParts: MessageWithParts): UIMessageL
         id: messageWithParts.id,
         role: messageWithParts.role,
         parts: sortedParts.map(mapDBPartToUIPart),
+        createdAt: messageWithParts.createdAt,
     };
 }
 


### PR DESCRIPTION
## Summary

- Messages now persist correctly when navigating between connections
- Existing messages load into the chat thread when opening a connection
- New messages save to the active connection instead of creating new ones

## Root Cause

The message persistence bug had two causes:

1. **connectionId not passed to API** - The runtime provider wasn't including `activeConnectionId` in request bodies, so every message created a new connection
2. **initialMessages not imported** - Messages loaded from the database were passed to `ConnectionProvider` but never imported into the assistant-ui runtime thread

## Changes

Modified `components/connection/connect-runtime-provider.tsx`:

- Inject `activeConnectionId` into POST request body via `fetchWithConcierge`
- Add `useEffect` that imports existing messages when connection changes
- Add `toThreadMessageLike()` converter to transform our `UIMessageLike` format to assistant-ui's `ThreadMessageLike` format

## Test plan

- [ ] Navigate to an existing connection with messages - messages should display
- [ ] Send a new message - should save to current connection (not create new)
- [ ] Switch between connections - each should show its own message history
- [ ] Create new connection - should start with empty thread
- [ ] Refresh page on existing connection - messages should reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Injects connectionId into API requests and imports initial messages into the chat thread on connection changes to ensure correct persistence and history loading.
> 
> - **Connection runtime (`components/connection/connect-runtime-provider.tsx`)**:
>   - Inject `connectionId` into POST bodies in `fetchWithConcierge` alongside model overrides.
>   - Initialize thread from `initialMessages` on connection changes using `toThreadMessageLike` and `ExportedMessageRepository`; track last import to avoid duplicates.
> - **DB mapping (`lib/db/message-mapping.ts`)**:
>   - Include `createdAt` in `mapDBMessageToUI` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc554422955f766824a94023d045fd633054ae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->