### PR TITLE
Fix code block formatting and colors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -300,7 +300,7 @@
 
     /* Code blocks */
     .holo-markdown .aui-md-pre {
-        @apply my-3 overflow-x-auto rounded-lg bg-foreground/10 p-4 font-mono text-sm;
+        @apply my-3 overflow-x-auto rounded-lg bg-muted p-4 font-mono text-sm text-foreground;
         backdrop-filter: blur(8px);
     }
 


### PR DESCRIPTION
Changed code block styling to improve text contrast:
- Background: bg-foreground/10 → bg-muted (solid, designed color)
- Text: implicit → text-foreground (explicit high contrast)

The previous 10% opacity background created insufficient contrast with the text, making code blocks hard to read. Now using the muted background color provides clear visual separation while maintaining readability in both light and dark modes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use `bg-muted` and explicit `text-foreground` for `.holo-markdown .aui-md-pre` to increase code block contrast.
> 
> - **Styles**:
>   - **Markdown code blocks** in `app/globals.css` (`.holo-markdown .aui-md-pre`):
>     - Change background from `bg-foreground/10` to `bg-muted`.
>     - Add `text-foreground` for explicit high-contrast text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fe317f010403892bd6b38b96caee468ceeb24d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->