### PR TITLE
💄 Polish sign-in and sign-up page branding

### DIFF
--- a/app/sign-in/[[...sign-in]]/page.tsx
+++ b/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,5 +1,8 @@
+import Image from "next/image";
 import { SignIn } from "@clerk/nextjs";
 import type { Metadata } from "next";
+
+import { HolographicBackground } from "@/components/ui/holographic-background";
 
 export const metadata: Metadata = {
     title: "Sign In | Carmenta",
@@ -9,36 +12,49 @@ export const metadata: Metadata = {
 
 export default function SignInPage() {
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-background">
-            <div className="mb-8 text-center">
-                <h1 className="text-2xl font-bold tracking-tight">CARMENTA_</h1>
-                <p className="mt-2 text-sm text-muted-foreground">
-                    Welcome back. Pick up where we left off.
-                </p>
+        <div className="relative flex min-h-screen flex-col">
+            <HolographicBackground />
+
+            <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6">
+                <div className="mb-8 flex flex-col items-center text-center">
+                    <Image
+                        src="/logos/icon-transparent.png"
+                        alt="Carmenta"
+                        width={64}
+                        height={64}
+                        className="mb-4 h-16 w-16"
+                        priority
+                    />
+                    <h1 className="text-2xl font-semibold tracking-tight text-foreground/90">
+                        Carmenta
+                    </h1>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Welcome back. Pick up where we left off.
+                    </p>
+                </div>
+                <SignIn
+                    appearance={{
+                        elements: {
+                            rootBox: "mx-auto",
+                            card: "glass-card border-0 shadow-none",
+                            headerTitle: "text-foreground",
+                            headerSubtitle: "text-muted-foreground",
+                            socialButtonsBlockButton:
+                                "bg-white/50 text-foreground hover:bg-white/80 border border-foreground/10 backdrop-blur-sm",
+                            socialButtonsBlockButtonText: "text-foreground font-medium",
+                            dividerLine: "bg-foreground/10",
+                            dividerText: "text-muted-foreground",
+                            formFieldLabel: "text-foreground",
+                            formFieldInput:
+                                "bg-white/50 border-foreground/10 text-foreground focus:ring-primary backdrop-blur-sm",
+                            formButtonPrimary: "btn-holo border-0",
+                            footerActionLink: "text-primary hover:text-primary/80",
+                            identityPreviewEditButton: "text-primary",
+                        },
+                    }}
+                    forceRedirectUrl="/connection"
+                />
             </div>
-            <SignIn
-                appearance={{
-                    elements: {
-                        rootBox: "mx-auto",
-                        card: "bg-card border border-border shadow-none",
-                        headerTitle: "text-foreground",
-                        headerSubtitle: "text-muted-foreground",
-                        socialButtonsBlockButton:
-                            "bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-border",
-                        socialButtonsBlockButtonText: "text-foreground font-medium",
-                        dividerLine: "bg-border",
-                        dividerText: "text-muted-foreground",
-                        formFieldLabel: "text-foreground",
-                        formFieldInput:
-                            "bg-background border-border text-foreground focus:ring-primary",
-                        formButtonPrimary:
-                            "bg-primary text-primary-foreground hover:bg-primary/90",
-                        footerActionLink: "text-primary hover:text-primary/80",
-                        identityPreviewEditButton: "text-primary",
-                    },
-                }}
-                forceRedirectUrl="/connection"
-            />
         </div>
     );
 }

--- a/app/sign-up/[[...sign-up]]/page.tsx
+++ b/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,5 +1,8 @@
+import Image from "next/image";
 import { SignUp } from "@clerk/nextjs";
 import type { Metadata } from "next";
+
+import { HolographicBackground } from "@/components/ui/holographic-background";
 
 export const metadata: Metadata = {
     title: "Sign Up | Carmenta",
@@ -9,36 +12,49 @@ export const metadata: Metadata = {
 
 export default function SignUpPage() {
     return (
-        <div className="flex min-h-screen flex-col items-center justify-center bg-background">
-            <div className="mb-8 text-center">
-                <h1 className="text-2xl font-bold tracking-tight">CARMENTA_</h1>
-                <p className="mt-2 text-sm text-muted-foreground">
-                    Start building together
-                </p>
+        <div className="relative flex min-h-screen flex-col">
+            <HolographicBackground />
+
+            <div className="relative z-10 flex min-h-screen flex-col items-center justify-center px-6">
+                <div className="mb-8 flex flex-col items-center text-center">
+                    <Image
+                        src="/logos/icon-transparent.png"
+                        alt="Carmenta"
+                        width={64}
+                        height={64}
+                        className="mb-4 h-16 w-16"
+                        priority
+                    />
+                    <h1 className="text-2xl font-semibold tracking-tight text-foreground/90">
+                        Carmenta
+                    </h1>
+                    <p className="mt-2 text-sm text-muted-foreground">
+                        Start building together
+                    </p>
+                </div>
+                <SignUp
+                    appearance={{
+                        elements: {
+                            rootBox: "mx-auto",
+                            card: "glass-card border-0 shadow-none",
+                            headerTitle: "text-foreground",
+                            headerSubtitle: "text-muted-foreground",
+                            socialButtonsBlockButton:
+                                "bg-white/50 text-foreground hover:bg-white/80 border border-foreground/10 backdrop-blur-sm",
+                            socialButtonsBlockButtonText: "text-foreground font-medium",
+                            dividerLine: "bg-foreground/10",
+                            dividerText: "text-muted-foreground",
+                            formFieldLabel: "text-foreground",
+                            formFieldInput:
+                                "bg-white/50 border-foreground/10 text-foreground focus:ring-primary backdrop-blur-sm",
+                            formButtonPrimary: "btn-holo border-0",
+                            footerActionLink: "text-primary hover:text-primary/80",
+                            identityPreviewEditButton: "text-primary",
+                        },
+                    }}
+                    forceRedirectUrl="/connection"
+                />
             </div>
-            <SignUp
-                appearance={{
-                    elements: {
-                        rootBox: "mx-auto",
-                        card: "bg-card border border-border shadow-none",
-                        headerTitle: "text-foreground",
-                        headerSubtitle: "text-muted-foreground",
-                        socialButtonsBlockButton:
-                            "bg-secondary text-secondary-foreground hover:bg-secondary/80 border border-border",
-                        socialButtonsBlockButtonText: "text-foreground font-medium",
-                        dividerLine: "bg-border",
-                        dividerText: "text-muted-foreground",
-                        formFieldLabel: "text-foreground",
-                        formFieldInput:
-                            "bg-background border-border text-foreground focus:ring-primary",
-                        formButtonPrimary:
-                            "bg-primary text-primary-foreground hover:bg-primary/90",
-                        footerActionLink: "text-primary hover:text-primary/80",
-                        identityPreviewEditButton: "text-primary",
-                    },
-                }}
-                forceRedirectUrl="/connection"
-            />
         </div>
     );
 }


### PR DESCRIPTION
## Summary

- Replace `CARMENTA_` placeholder text with proper logo and "Carmenta" branding
- Add holographic background animation (matching the landing page)
- Apply glassmorphism styling to Clerk components (glass-card, btn-holo)
- Use consistent typography and spacing with the rest of the site

## Before vs After

**Before:** Plain white background, all-caps `CARMENTA_` placeholder
**After:** Holographic dream theme, logo image, glassmorphism cards, proper brand typography

## Test plan

- [ ] Visit `/sign-in` and verify branding matches the landing page aesthetic
- [ ] Visit `/sign-up` and verify consistent styling with sign-in
- [ ] Test sign-in flow works correctly
- [ ] Test sign-up flow works correctly
- [ ] Verify responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates sign-in and sign-up pages with a holographic background, logo, and glassmorphism-styled Clerk components.
> 
> - **Frontend**
>   - **Auth pages** (`app/sign-in/[[...sign-in]]/page.tsx`, `app/sign-up/[[...sign-up]]/page.tsx`):
>     - Add `HolographicBackground` and branded logo via `next/image`.
>     - Replace plain layout with glassmorphism styling for Clerk (`glass-card`, `btn-holo`, updated element classes).
>     - Adjust structure and spacing to center content and align with site branding.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e263bab7900b61bf8c19ce304bc43c3b8533e966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->