### PR TITLE
🐛 Fix email conflict in getOrCreateUser + fix test docs

### DIFF
--- a/.cursor/rules/testing-standards-typescript.mdc
+++ b/.cursor/rules/testing-standards-typescript.mdc
@@ -343,21 +343,21 @@ CPU indefinitely when interrupted.
 Run specific test file:
 
 ```bash
-bun test -- path/to/file.test.ts
-bun test -- __tests__/unit/lib/adapters/notion.test.ts
+bun run test path/to/file.test.ts
+bun run test __tests__/unit/lib/adapters/notion.test.ts
 ```
 
 Filter by test name:
 
 ```bash
-bun test -- -t "pattern"
-bun test -- -t "should handle errors"
+bun run test -t "pattern"
+bun run test -t "should handle errors"
 ```
 
 Run all tests:
 
 ```bash
-bun test
+bun run test
 ```
 
 File paths are positional arguments, not flags. Use `-t` or `--testNamePattern` to

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ bun install
 bun dev
 
 # Run tests
-bun test
+bun run test
 
 # Type check
 bun type-check

--- a/__tests__/unit/lib/db/users.test.ts
+++ b/__tests__/unit/lib/db/users.test.ts
@@ -120,6 +120,34 @@ describe("User Database Operations", () => {
             // Both should return the same user (upsert handles conflict)
             expect(user1.id).toBe(user2.id);
         });
+
+        it("updates clerk_id when same email appears with different clerk_id", async () => {
+            // Use unique identifiers to avoid test isolation issues
+            const uniqueId = Date.now().toString();
+            const testEmail = `reregistered-${uniqueId}@example.com`;
+            const originalClerkId = `clerk_original_${uniqueId}`;
+            const newClerkId = `clerk_new_${uniqueId}`;
+
+            // Setup: User exists with original clerk_id
+            // This happens when: user re-registers, switches OAuth providers,
+            // or Clerk user ID changes for any reason
+            await db.insert(schema.users).values({
+                clerkId: originalClerkId,
+                email: testEmail,
+                firstName: "Original",
+            });
+
+            // Act: Same email, different clerk_id (simulates re-registration)
+            const user = await getOrCreateUser(newClerkId, testEmail, {
+                firstName: "Updated",
+                lastName: "Name",
+            });
+
+            // Assert: Should succeed and update the clerk_id
+            expect(user.email).toBe(testEmail);
+            expect(user.clerkId).toBe(newClerkId);
+            expect(user.firstName).toBe("Updated");
+        });
     });
 
     describe("updateUserPreferences", () => {

--- a/knowledge/components/testing.md
+++ b/knowledge/components/testing.md
@@ -64,19 +64,19 @@ explicit, type-safe data creation.
 
 ```bash
 # Run all unit/integration tests
-bun test
+bun run test
 
 # Run specific test file
-bun vitest run __tests__/unit/lib/utils.test.ts
+bun run test __tests__/unit/lib/utils.test.ts
 
 # Run tests matching pattern
-bun vitest run -t "validates email"
+bun run test -t "validates email"
 
 # Run with coverage
-bun test:coverage
+bun run test:coverage
 
 # Run E2E tests
-bun test:e2e
+bun run test:e2e
 
 # Run E2E in headed mode
 bun playwright test --headed

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -114,6 +114,7 @@ vi.mock("./lib/db/index", async () => {
         }
     ) => {
         // Pure upsert: single atomic operation eliminates race conditions
+        // Email is the canonical identity - update clerk_id if it changed
         const [user] = await db
             .insert(schema.users)
             .values({
@@ -126,8 +127,12 @@ vi.mock("./lib/db/index", async () => {
                 lastSignedInAt: new Date(),
             })
             .onConflictDoUpdate({
-                target: schema.users.clerkId,
+                target: schema.users.email,
                 set: {
+                    clerkId,
+                    firstName: profile?.firstName,
+                    lastName: profile?.lastName,
+                    imageUrl: profile?.imageUrl,
                     lastSignedInAt: new Date(),
                     updatedAt: new Date(),
                 },


### PR DESCRIPTION
## Summary

- **Bug fix**: Changed upsert conflict target from `clerk_id` to `email` - email is now the canonical user identity
- **Test fix**: Added test case for "same email, different clerk_id" scenario  
- **Docs fix**: Changed `bun test` to `bun run test` in all docs

## Problem

When navigating to `/connections/new`, users with a different Clerk ID but same email got a `duplicate key value violates unique constraint "users_email_unique"` error. This happens when:
- User re-registers after deleting their account
- User switches OAuth providers (Google → GitHub)
- Clerk user ID changes for any reason

## Solution

Email is the canonical user identity. If the same email appears with a different Clerk ID, we update the Clerk ID to match (instead of failing).

## Bonus fix

Discovered that `bun test` ≠ `bun run test`:
- `bun test` → bun's native test runner (ignores vitest.setup.ts, no PGlite mocks)
- `bun run test` → vitest (uses setup file with PGlite mocks)

Updated all docs to use `bun run test`.

## Test plan

- [x] All 462 tests pass
- [x] New test covers "same email, different clerk_id" scenario
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch getOrCreateUser upsert conflict to email (updating clerkId/profile on conflict), add a unit test for re-registered users, and update docs to use `bun run test`.
> 
> - **Backend**
>   - `lib/db/users.ts`: Change upsert conflict target to `users.email` in `getOrCreateUser`; update to set `clerkId` and profile fields on conflict.
>   - `vitest.setup.ts`: Mirror upsert change in test DB mock (`target: schema.users.email`, set `clerkId` and profile fields).
> - **Tests**
>   - `__tests__/unit/lib/db/users.test.ts`: Add test ensuring same `email` with different `clerkId` updates `clerkId` and profile.
> - **Docs**
>   - `.cursor/rules/testing-standards-typescript.mdc`, `knowledge/components/testing.md`, `README.md`: Replace `bun test` with `bun run test`; clarify correct Vitest CLI usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17139453ee14e8e9d94b7f1d81514766cb71ec98. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->