### PR TITLE
🐛 Fix chat streaming not displaying messages for new connections

### DIFF
--- a/components/connection/connect-runtime-provider.tsx
+++ b/components/connection/connect-runtime-provider.tsx
@@ -414,14 +414,20 @@ function ConnectRuntimeProviderInner({ children }: ConnectRuntimeProviderProps) 
     const handleNewConnectionCreated = useCallback(
         (slug: string, connectionId: string) => {
             logger.debug({ slug, connectionId }, "Updating URL for new connection");
-            // Update URL without triggering Next.js navigation/page load
+            // Update URL without triggering Next.js navigation/page load.
+            // We preserve existing history.state (which contains Next.js router state like __NA)
+            // to avoid breaking back/forward navigation. Adding connectionId for potential
+            // future use in popstate handling.
             window.history.replaceState(
                 { ...window.history.state, connectionId },
                 "",
                 `/connection/${slug}`
             );
             // Update document title to match new connection
-            document.title = `${slug.split("-")[0].charAt(0).toUpperCase() + slug.split("-")[0].slice(1)} | Carmenta`;
+            const titleWord = slug.split("-")[0] || "Connection";
+            const capitalizedTitle =
+                titleWord.charAt(0).toUpperCase() + titleWord.slice(1);
+            document.title = `${capitalizedTitle} | Carmenta`;
         },
         []
     );


### PR DESCRIPTION
## Summary

- Fixed critical bug where messages weren't appearing after submitting a chat message
- Root cause: `useChat` hook was initialized with `undefined` ID for new connections, then `router.replace()` triggered a full page reload when the connection was created, losing stream state
- Solution: Generate stable client-side chat ID (matching Vercel's ai-chatbot pattern) and use `window.history.replaceState` for URL updates without navigation

## What Changed

1. **Generate stable `pendingChatId` client-side** for new connections using AI SDK's `generateId()`
2. **Use `effectiveChatId`** (existing connection ID or pending ID) for `useChat` so messages are tracked consistently throughout the stream
3. **Replace `router.replace()` with `window.history.replaceState`** to update URL without triggering Next.js navigation/page reload
4. **Update message sync effect** to preserve messages when connection ID transitions from `null` to a real value (stream completion)

## Test plan

- [x] Verified messages now appear when sending first message to new connection
- [x] Verified URL updates correctly without page reload
- [x] Verified stream completes and assistant response displays
- [x] All 462 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Uses a stable client-generated chat ID and history.replaceState to keep streaming messages visible when creating a new connection, with updated fetch/transport and message sync logic.
> 
> - **Chat runtime**:
>   - Generate stable `pendingChatId` via `generateId()` and use `effectiveChatId` for `useChat` to maintain state before server assigns an ID.
>   - Refactor message sync: load messages on connection navigation; avoid clearing during new-connection creation; only clear when moving from existing to new.
> - **Transport/networking**:
>   - Extend `createFetchWrapper` to accept `onNewConnectionCreated` and call it when server signals a new connection via headers.
>   - Update URL on new connection with `window.history.replaceState` (no navigation) and adjust transport memo deps.
> - **Minor**:
>   - Import `generateId` and small logging/typing additions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b175cd25b249a89021ba44cd700c9a20a6467d6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->