### PR TITLE
✨ Add shimmer animation and glass styling to ThinkingIndicator

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -406,6 +406,27 @@
         animation: spin-slow 2s linear infinite;
     }
 
+    /* Subtle shimmer for loading states - GPU accelerated */
+    @keyframes shimmer {
+        0% {
+            background-position: -200% 0;
+        }
+        100% {
+            background-position: 200% 0;
+        }
+    }
+
+    .animate-shimmer {
+        background: linear-gradient(
+            90deg,
+            hsl(var(--muted) / 0.3) 0%,
+            hsl(var(--muted) / 0.5) 50%,
+            hsl(var(--muted) / 0.3) 100%
+        );
+        background-size: 200% 100%;
+        animation: shimmer 2s ease-in-out infinite;
+    }
+
     /*
      * Oracle Animations
      *

--- a/components/connection/thinking-indicator.tsx
+++ b/components/connection/thinking-indicator.tsx
@@ -45,8 +45,15 @@ export function ThinkingIndicator({ className }: ThinkingIndicatorProps) {
             animate={{ opacity: 1, y: 0 }}
             exit={{ opacity: 0, y: -8 }}
             transition={{ duration: 0.2 }}
-            className={cn("flex items-center gap-3", className)}
+            className={cn(
+                "relative flex items-center gap-3 rounded-lg px-4 py-3",
+                "border border-white/20 bg-white/30 backdrop-blur-sm",
+                className
+            )}
         >
+            {/* Shimmer overlay */}
+            <div className="animate-shimmer absolute inset-0 rounded-lg opacity-50" />
+
             {/* Rotating logo */}
             <div className="relative flex h-8 w-8 items-center justify-center">
                 <div className="animate-spin-slow">
@@ -61,7 +68,7 @@ export function ThinkingIndicator({ className }: ThinkingIndicatorProps) {
             </div>
 
             {/* Message */}
-            <div className="flex items-baseline gap-2">
+            <div className="relative flex items-baseline gap-2">
                 <span className="text-sm text-muted-foreground">{message}</span>
                 {showTime && (
                     <span className="text-xs text-muted-foreground/60">


### PR DESCRIPTION
## Summary

Implements glass card styling with shimmer overlay for the thinking/loading state, per `knowledge/components/status-indicators.md` spec.

### Changes

- **Shimmer CSS animation** (GPU-accelerated) added to `globals.css`
- **ThinkingIndicator** wrapped in glass card with backdrop blur and shimmer overlay
- Shimmer runs continuously at 50% opacity for subtle effect

## Review Findings: Status Indicator Pathways

During comprehensive code review, I analyzed all user waiting pathways. Here's the current state:

### ✅ Working Well

| Component | Purpose | Status |
|-----------|---------|--------|
| `ThinkingIndicator` | Initial wait for AI response | Complete (now with shimmer) |
| `ReasoningDisplay` | Extended thinking (Claude reasoning) | Complete with auto-collapse |
| `ToolStatusBadge` | 4-state tool status | Complete |
| `ToolWrapper` | Tool container with timing/celebration | Complete |
| `RunningIndicator` | Connection streaming indicator | Complete |
| Tool-specific loading | Each tool has skeleton screens | Complete |

### ⚠️ Gap Identified: Tool UI Rendering

The API stores tool call parts (lines 536-546 in `route.ts`):
```typescript
parts.push({
    type: `tool-${tc.toolName}`,
    toolCallId: tc.toolCallId,
    state: toolResult ? "output-available" : "input-available",
    input: tc.input,
    ...(toolResult && { output: toolResult.output }),
});
```

**But HoloThread only renders `text` and `reasoning` parts** - tool UIs are not displayed!

The components exist (`WebSearchResults`, `DeepResearchResult`, `CompareTable`, etc.) but aren't wired up. This means when a user triggers weather lookup, search, or comparison, they won't see the tool's loading state or results.

**This is a separate ticket** - the status indicator components are complete, they just need to be rendered in the message thread.

## Testing

- Build passes ✓
- All 497 tests pass ✓
- TypeScript compiles ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)