### PR TITLE
✨ Wire up tool UI rendering in HoloThread

### DIFF
--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -321,6 +321,7 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                       windSpeed?: number;
                   }
                 | undefined;
+            const weatherError = getToolError(part, output, "Weather check failed");
 
             return (
                 <ToolWrapper
@@ -329,10 +330,15 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                     status={status}
                     input={input}
                     output={output}
+                    error={weatherError}
                 >
                     {status === "running" ? (
                         <div className="animate-pulse text-sm text-muted-foreground">
                             Checking weather for {input?.location as string}...
+                        </div>
+                    ) : status === "error" ? (
+                        <div className="text-sm text-destructive">
+                            {weatherError ?? "Weather check failed"}
                         </div>
                     ) : weatherOutput ? (
                         <div className="text-sm">
@@ -352,8 +358,16 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
             );
         }
 
-        default:
+        default: {
             // Unknown tools get a generic wrapper
+            const defaultError = getToolError(part, output, "Tool failed");
+            const statusText =
+                status === "running"
+                    ? "Processing..."
+                    : status === "error"
+                      ? (defaultError ?? "Tool failed")
+                      : "Complete";
+
             return (
                 <ToolWrapper
                     toolName={toolName}
@@ -361,12 +375,16 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                     status={status}
                     input={input}
                     output={output}
+                    error={defaultError}
                 >
-                    <div className="text-sm text-muted-foreground">
-                        {status === "running" ? "Processing..." : "Complete"}
+                    <div
+                        className={`text-sm ${status === "error" ? "text-destructive" : "text-muted-foreground"}`}
+                    >
+                        {statusText}
                     </div>
                 </ToolWrapper>
             );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Tool parts (weather, search, comparison, etc.) were stored by the API but never displayed - HoloThread only rendered text and reasoning parts
- Adds `ToolPart` interface matching API storage format (`tool-{name}` pattern)
- Adds `ToolPartRenderer` component mapping tools to their UI components
- Tool UIs now render between reasoning and text content

**Tool → Component Mapping:**
| Tool | Component |
|------|-----------|
| `webSearch` | `WebSearchResults` |
| `compareOptions` | `CompareTable` |
| `fetchPage` | `FetchPageResult` |
| `deepResearch` | `DeepResearchResult` |
| `getWeather` | `ToolWrapper` with inline weather card |
| Unknown | Generic `ToolWrapper` fallback |

## Test plan

- [ ] Trigger weather lookup ("What's the weather in NYC?") and verify WeatherCard appears
- [ ] Trigger web search and verify WebSearchResults renders
- [ ] Trigger comparison and verify CompareTable renders
- [ ] Verify tool status shows "running" while executing, "completed" when done

🤖 Generated with [Claude Code](https://claude.com/claude-code)