### PR TITLE
🐛 Fix pasted text validation error

### DIFF
--- a/__tests__/unit/lib/storage/file-config.test.ts
+++ b/__tests__/unit/lib/storage/file-config.test.ts
@@ -1,0 +1,163 @@
+/**
+ * File Config Tests
+ *
+ * Tests for file configuration exports and utility functions.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+    ALLOWED_MIME_TYPES,
+    MIME_TYPE_WHITELIST,
+    SIZE_LIMITS,
+    PASTE_THRESHOLD,
+    getFileCategory,
+    getSizeLimit,
+    formatFileSize,
+    getSupportedFormatsMessage,
+} from "@/lib/storage/file-config";
+
+describe("ALLOWED_MIME_TYPES", () => {
+    it("includes image types", () => {
+        expect(ALLOWED_MIME_TYPES.image).toContain("image/jpeg");
+        expect(ALLOWED_MIME_TYPES.image).toContain("image/png");
+        expect(ALLOWED_MIME_TYPES.image).toContain("image/gif");
+        expect(ALLOWED_MIME_TYPES.image).toContain("image/webp");
+    });
+
+    it("includes audio types", () => {
+        expect(ALLOWED_MIME_TYPES.audio).toContain("audio/mp3");
+        expect(ALLOWED_MIME_TYPES.audio).toContain("audio/wav");
+        expect(ALLOWED_MIME_TYPES.audio).toContain("audio/mpeg");
+        expect(ALLOWED_MIME_TYPES.audio).toContain("audio/flac");
+    });
+
+    it("includes document types", () => {
+        expect(ALLOWED_MIME_TYPES.document).toContain("application/pdf");
+    });
+
+    it("does not include text types (Anthropic API limitation)", () => {
+        expect(ALLOWED_MIME_TYPES).not.toHaveProperty("text");
+    });
+});
+
+describe("MIME_TYPE_WHITELIST", () => {
+    it("is a flattened array of all allowed types", () => {
+        const allTypes = [
+            ...ALLOWED_MIME_TYPES.image,
+            ...ALLOWED_MIME_TYPES.audio,
+            ...ALLOWED_MIME_TYPES.document,
+        ];
+        expect(MIME_TYPE_WHITELIST).toEqual(expect.arrayContaining(allTypes));
+        expect(MIME_TYPE_WHITELIST.length).toBe(allTypes.length);
+    });
+});
+
+describe("SIZE_LIMITS", () => {
+    it("has correct image limit (10MB)", () => {
+        expect(SIZE_LIMITS.image).toBe(10 * 1024 * 1024);
+    });
+
+    it("has correct audio limit (25MB)", () => {
+        expect(SIZE_LIMITS.audio).toBe(25 * 1024 * 1024);
+    });
+
+    it("has correct document limit (25MB)", () => {
+        expect(SIZE_LIMITS.document).toBe(25 * 1024 * 1024);
+    });
+});
+
+describe("PASTE_THRESHOLD", () => {
+    it("is 1000 characters", () => {
+        expect(PASTE_THRESHOLD).toBe(1000);
+    });
+});
+
+describe("getFileCategory", () => {
+    it("returns 'image' for image MIME types", () => {
+        expect(getFileCategory("image/jpeg")).toBe("image");
+        expect(getFileCategory("image/png")).toBe("image");
+        expect(getFileCategory("image/gif")).toBe("image");
+        expect(getFileCategory("image/webp")).toBe("image");
+    });
+
+    it("returns 'document' for PDF", () => {
+        expect(getFileCategory("application/pdf")).toBe("document");
+    });
+
+    it("returns 'audio' for audio MIME types", () => {
+        expect(getFileCategory("audio/mp3")).toBe("audio");
+        expect(getFileCategory("audio/wav")).toBe("audio");
+        expect(getFileCategory("audio/mpeg")).toBe("audio");
+        expect(getFileCategory("audio/flac")).toBe("audio");
+        expect(getFileCategory("audio/mp4")).toBe("audio");
+        expect(getFileCategory("audio/x-m4a")).toBe("audio");
+    });
+
+    it("returns null for unsupported types", () => {
+        expect(getFileCategory("text/plain")).toBeNull();
+        expect(getFileCategory("video/mp4")).toBeNull();
+        expect(getFileCategory("application/zip")).toBeNull();
+        expect(getFileCategory("application/octet-stream")).toBeNull();
+    });
+});
+
+describe("getSizeLimit", () => {
+    it("returns correct limit for images", () => {
+        expect(getSizeLimit("image/jpeg")).toBe(10 * 1024 * 1024);
+        expect(getSizeLimit("image/png")).toBe(10 * 1024 * 1024);
+    });
+
+    it("returns correct limit for audio", () => {
+        expect(getSizeLimit("audio/mp3")).toBe(25 * 1024 * 1024);
+        expect(getSizeLimit("audio/wav")).toBe(25 * 1024 * 1024);
+    });
+
+    it("returns correct limit for documents", () => {
+        expect(getSizeLimit("application/pdf")).toBe(25 * 1024 * 1024);
+    });
+
+    it("returns null for unsupported types", () => {
+        expect(getSizeLimit("text/plain")).toBeNull();
+        expect(getSizeLimit("video/mp4")).toBeNull();
+    });
+});
+
+describe("formatFileSize", () => {
+    it("formats 0 bytes", () => {
+        expect(formatFileSize(0)).toBe("0 Bytes");
+    });
+
+    it("formats bytes", () => {
+        expect(formatFileSize(500)).toBe("500 Bytes");
+    });
+
+    it("formats KB", () => {
+        expect(formatFileSize(1024)).toBe("1 KB");
+        expect(formatFileSize(2048)).toBe("2 KB");
+    });
+
+    it("formats MB", () => {
+        expect(formatFileSize(1024 * 1024)).toBe("1 MB");
+        expect(formatFileSize(10 * 1024 * 1024)).toBe("10 MB");
+    });
+
+    it("formats GB", () => {
+        expect(formatFileSize(1024 * 1024 * 1024)).toBe("1 GB");
+    });
+
+    it("rounds to 2 decimal places", () => {
+        expect(formatFileSize(1536)).toBe("1.5 KB");
+        expect(formatFileSize(1.5 * 1024 * 1024)).toBe("1.5 MB");
+    });
+});
+
+describe("getSupportedFormatsMessage", () => {
+    it("returns human-readable format list", () => {
+        const message = getSupportedFormatsMessage();
+        expect(message).toContain("Images");
+        expect(message).toContain("JPEG");
+        expect(message).toContain("PNG");
+        expect(message).toContain("PDFs");
+        expect(message).toContain("audio");
+    });
+});

--- a/__tests__/unit/lib/storage/file-validator.test.ts
+++ b/__tests__/unit/lib/storage/file-validator.test.ts
@@ -1,0 +1,170 @@
+/**
+ * File Validator Tests
+ *
+ * Tests for file validation logic (MIME type checking, size limits, etc.)
+ */
+
+import { describe, it, expect } from "vitest";
+import { validateFile, validateFiles } from "@/lib/storage/file-validator";
+import {
+    createTestImageFile,
+    createTestPDFFile,
+    createTestTextFile,
+    createTestAudioFile,
+} from "@/__tests__/fixtures/file-fixtures";
+
+describe("validateFile", () => {
+    describe("valid files", () => {
+        it("accepts valid image files", () => {
+            const file = createTestImageFile();
+            const result = validateFile(file);
+            expect(result).toEqual({ valid: true });
+        });
+
+        it("accepts valid PDF files", () => {
+            const file = createTestPDFFile();
+            const result = validateFile(file);
+            expect(result).toEqual({ valid: true });
+        });
+
+        it("accepts valid audio files", () => {
+            const file = createTestAudioFile();
+            const result = validateFile(file);
+            expect(result).toEqual({ valid: true });
+        });
+    });
+
+    describe("empty files", () => {
+        it("rejects empty files", () => {
+            const file = new File([], "empty.jpg", { type: "image/jpeg" });
+            const result = validateFile(file);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("empty");
+        });
+    });
+
+    describe("unsupported MIME types", () => {
+        it("rejects text/plain files", () => {
+            const file = createTestTextFile("hello world", "test.txt");
+            const result = validateFile(file);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("don't support text/plain");
+        });
+
+        it("rejects video files", () => {
+            const file = new File([new ArrayBuffer(1024)], "video.mp4", {
+                type: "video/mp4",
+            });
+            const result = validateFile(file);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("don't support video/mp4");
+        });
+
+        it("rejects archive files", () => {
+            const file = new File([new ArrayBuffer(1024)], "archive.zip", {
+                type: "application/zip",
+            });
+            const result = validateFile(file);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("don't support application/zip");
+        });
+
+        it("rejects files with no MIME type", () => {
+            const file = new File([new ArrayBuffer(1024)], "unknown.exe", {
+                type: "",
+            });
+            const result = validateFile(file);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("this file type");
+        });
+
+        it("includes supported formats in error message", () => {
+            const file = createTestTextFile("test", "test.txt");
+            const result = validateFile(file);
+            expect(result.error).toContain("Images");
+            expect(result.error).toContain("PDFs");
+            expect(result.error).toContain("audio");
+        });
+    });
+
+    describe("size limits", () => {
+        it("rejects images over 10MB", () => {
+            const bigFile = new File([new ArrayBuffer(11 * 1024 * 1024)], "big.jpg", {
+                type: "image/jpeg",
+            });
+            const result = validateFile(bigFile);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("10 MB");
+        });
+
+        it("accepts images under 10MB", () => {
+            const file = new File([new ArrayBuffer(5 * 1024 * 1024)], "medium.jpg", {
+                type: "image/jpeg",
+            });
+            const result = validateFile(file);
+            expect(result).toEqual({ valid: true });
+        });
+
+        it("rejects audio over 25MB", () => {
+            const bigFile = new File([new ArrayBuffer(26 * 1024 * 1024)], "big.mp3", {
+                type: "audio/mp3",
+            });
+            const result = validateFile(bigFile);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("25 MB");
+        });
+
+        it("rejects PDFs over 25MB", () => {
+            const bigFile = new File([new ArrayBuffer(26 * 1024 * 1024)], "big.pdf", {
+                type: "application/pdf",
+            });
+            const result = validateFile(bigFile);
+            expect(result.valid).toBe(false);
+            expect(result.error).toContain("25 MB");
+        });
+
+        it("includes file category in size error", () => {
+            const bigFile = new File([new ArrayBuffer(11 * 1024 * 1024)], "big.png", {
+                type: "image/png",
+            });
+            const result = validateFile(bigFile);
+            expect(result.error).toContain("image");
+        });
+
+        it("includes actual file size in error", () => {
+            const bigFile = new File([new ArrayBuffer(15 * 1024 * 1024)], "big.jpg", {
+                type: "image/jpeg",
+            });
+            const result = validateFile(bigFile);
+            expect(result.error).toContain("15 MB");
+        });
+    });
+});
+
+describe("validateFiles", () => {
+    it("returns valid when all files pass", () => {
+        const files = [
+            createTestImageFile(),
+            createTestPDFFile(),
+            createTestAudioFile(),
+        ];
+        const result = validateFiles(files);
+        expect(result).toEqual({ valid: true });
+    });
+
+    it("returns first error when a file fails", () => {
+        const files = [
+            createTestImageFile(),
+            createTestTextFile("invalid", "test.txt"),
+            createTestPDFFile(),
+        ];
+        const result = validateFiles(files);
+        expect(result.valid).toBe(false);
+        expect(result.error).toContain("text/plain");
+    });
+
+    it("returns valid for empty array", () => {
+        const result = validateFiles([]);
+        expect(result).toEqual({ valid: true });
+    });
+});

--- a/components/connection/file-attachment-context.tsx
+++ b/components/connection/file-attachment-context.tsx
@@ -153,20 +153,19 @@ export function FileAttachmentProvider({ children }: { children: ReactNode }) {
         return nextCount === 1 ? "Pasted Image.png" : `Pasted Image ${nextCount}.png`;
     }, []);
 
-    const addPastedText = useCallback(
-        (fileList: File[], textContent: string) => {
-            const files = Array.from(fileList);
-            const newUploads: UploadProgress[] = files.map((file) => {
-                const id = nanoid();
-                pastedTextContentRef.current.set(id, textContent);
-                return { id, file, status: "validating" as const };
-            });
+    const addPastedText = useCallback((fileList: File[], textContent: string) => {
+        const files = Array.from(fileList);
+        const newUploads: UploadProgress[] = files.map((file) => {
+            const id = nanoid();
+            pastedTextContentRef.current.set(id, textContent);
+            // Mark complete immediately - no upload needed
+            // Pasted text is stored locally and auto-inlined on send
+            return { id, file, status: "complete" as const };
+        });
 
-            dispatch({ type: "ADD", uploads: newUploads });
-            newUploads.forEach((upload) => startUpload(upload));
-        },
-        [startUpload]
-    );
+        dispatch({ type: "ADD", uploads: newUploads });
+        // Skip startUpload() - text files don't need storage upload
+    }, []);
 
     const getTextContent = useCallback((fileId: string) => {
         return pastedTextContentRef.current.get(fileId);


### PR DESCRIPTION
## Summary

- Fixes bug where pasting large text (>1000 chars) showed "We don't support text/plain" error
- The bug occurred because `addPastedText()` was trying to upload the file to Supabase, triggering MIME type validation
- The design intent (per code comments) is that pasted text should appear as a UI "attachment" but NOT actually upload — it gets auto-inlined as message text on send

## Changes

- Modified `addPastedText()` to mark files as `"complete"` immediately without calling `startUpload()`
- Added comprehensive unit tests for `file-validator.ts` and `file-config.ts`

## Test plan

- [ ] Paste large text (>1000 chars) into composer
- [ ] Should see "Pasted Content.txt" with ✅ Complete status (green checkmark)
- [ ] Should see "Insert inline" link
- [ ] Click "Insert inline" → text appears in input
- [ ] Click send → text auto-inlined, message sent successfully
- [ ] No "We don't support text/plain" error should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)