### PR TITLE
🔧 Add /api/connect/save fallback endpoint for OAuth connections

### DIFF
--- a/app/api/connect/save/route.ts
+++ b/app/api/connect/save/route.ts
@@ -76,27 +76,11 @@ export async function POST(req: Request) {
             imageUrl: user.imageUrl ?? null,
         });
 
-        // Fetch account info
-        let accountId: string;
-        let accountDisplayName: string;
-
-        try {
-            const accountInfo = await fetchAccountInfo(
-                service,
-                connectionId,
-                dbUser.id
-            );
-            accountId = accountInfo.identifier;
-            accountDisplayName = accountInfo.displayName;
-        } catch (error) {
-            logger.error(
-                { error, service, connectionId, userId: dbUser.id },
-                "Failed to fetch account info in save endpoint"
-            );
-            // Use defaults
-            accountId = connectionId;
-            accountDisplayName = service;
-        }
+        // Fetch account info to get the actual identifier
+        // Errors bubble up to route error handler - no silent failures
+        const accountInfo = await fetchAccountInfo(service, connectionId, dbUser.id);
+        const accountId = accountInfo.identifier;
+        const accountDisplayName = accountInfo.displayName;
 
         // Upsert integration (idempotent)
         await db.transaction(async (tx) => {

--- a/app/connect/[service]/page.tsx
+++ b/app/connect/[service]/page.tsx
@@ -90,6 +90,8 @@ export default function ConnectServicePage() {
                                         { status: saveResponse.status },
                                         "Failed to save connection"
                                     );
+                                    setError("Failed to save connection");
+                                    return;
                                 }
 
                                 logger.info(

--- a/lib/integrations/adapters/notion.ts
+++ b/lib/integrations/adapters/notion.ts
@@ -90,20 +90,17 @@ export class NotionAdapter extends ServiceAdapter {
     /**
      * Fetch the Notion workspace information
      * Used to populate accountIdentifier and accountDisplayName after OAuth
+     *
+     * @param connectionId - Nango connection ID (required for OAuth webhook flow)
+     * @param userId - User ID (optional, only used for logging)
      */
-    async fetchAccountInfo(userId: string): Promise<{
+    async fetchAccountInfo(
+        connectionId: string,
+        userId?: string
+    ): Promise<{
         identifier: string;
         displayName: string;
     }> {
-        const credentials = await getCredentials(userId, this.serviceName);
-
-        if (!credentials.connectionId) {
-            throw new ValidationError(
-                `No Nango connection ID found for ${this.serviceDisplayName}. ` +
-                    `Please reconnect your account at /integrations/${this.serviceName}`
-            );
-        }
-
         const nangoUrl = this.getNangoUrl();
         const nangoSecretKey = getNangoSecretKey();
 
@@ -113,7 +110,7 @@ export class NotionAdapter extends ServiceAdapter {
                 .get(`${nangoUrl}/proxy/v1/users/me`, {
                     headers: {
                         Authorization: `Bearer ${nangoSecretKey}`,
-                        "Connection-Id": credentials.connectionId,
+                        "Connection-Id": connectionId,
                         "Provider-Config-Key": "notion",
                         "Notion-Version": NOTION_API_VERSION,
                     },
@@ -141,7 +138,10 @@ export class NotionAdapter extends ServiceAdapter {
                 displayName: workspaceName,
             };
         } catch (error) {
-            this.logError("Failed to fetch Notion account info:", error);
+            logger.error(
+                { error, userId, connectionId },
+                "📝 Failed to fetch Notion account info"
+            );
             throw new ValidationError("Failed to fetch Notion account information");
         }
     }

--- a/lib/integrations/fetch-account-info.ts
+++ b/lib/integrations/fetch-account-info.ts
@@ -39,17 +39,11 @@ export async function fetchAccountInfo(
         }
 
         case "notion": {
-            // Notion adapter expects (userId) only
-            // We need to get userId from the connection or throw error
-            if (!userId) {
-                throw new ValidationError(
-                    "User ID is required for fetching Notion account info"
-                );
-            }
             const { NotionAdapter } =
                 await import("@/lib/integrations/adapters/notion");
             const adapter = new NotionAdapter();
-            return await adapter.fetchAccountInfo(userId);
+            // Notion adapter expects (connectionId, userId?)
+            return await adapter.fetchAccountInfo(connectionId, userId);
         }
 
         default:


### PR DESCRIPTION
## Summary

Fixes OAuth connection bug where ClickUp and Notion connections appeared successful in Nango dashboard but weren't saved to the database.

## Problem

OAuth flows completed successfully (visible in Nango dashboard), but services remained in "Available" instead of "Connected" on the integrations page. Root cause: Carmenta only relied on Nango webhooks to create database records.

Known Nango webhook issues:
- Webhooks can arrive without `endUser.id` (documented Nango limitation)
- Race conditions: webhook may arrive after page navigates away
- Webhook failures: network issues, timeout, etc.

## Solution

Implemented dual-save pattern from mcp-hubby (battle-tested, production-quality code):
1. **Frontend immediately calls `/api/connect/save`** after OAuth success
2. **Webhook handler also saves** (same idempotent upsert logic)
3. **Whichever arrives first wins**, the other updates existing record

## Changes

- **`/app/api/connect/save/route.ts`** (new) - Fallback endpoint for immediate connection save
- **`/app/connect/[service]/page.tsx`** (modified) - Call save endpoint on "connect" event
- **`/lib/integrations/fetch-account-info.ts`** (new) - Centralized account info fetching
- **`/app/api/webhooks/nango/route.ts`** (modified) - Use centralized fetchAccountInfo

## Pattern from mcp-hubby

This implementation mirrors the proven approach from mcp-hubby:
- Idempotent upsert logic prevents duplicates
- Immediate frontend save = instant UI feedback
- Webhook save = backup for edge cases
- `fetchAccountInfo` handles service-specific account details

## Testing

- [x] Pre-commit checks passed
- [x] All tests passing (614 passed)
- [x] TypeScript type-check passed
- [ ] Manual OAuth flow testing needed (ClickUp, Notion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)