### PR TITLE
✨ Add Google Calendar/Contacts integration

### DIFF
--- a/lib/integrations/adapters/google.ts
+++ b/lib/integrations/adapters/google.ts
@@ -1461,7 +1461,10 @@ export class GoogleAdapter extends ServiceAdapter {
         };
 
         if (given_name !== undefined || family_name !== undefined) {
-            body.names = [{ givenName: given_name, familyName: family_name }];
+            const nameObj: { givenName?: string; familyName?: string } = {};
+            if (given_name !== undefined) nameObj.givenName = given_name;
+            if (family_name !== undefined) nameObj.familyName = family_name;
+            body.names = [nameObj];
             updateFields.push("names");
         }
         if (emails !== undefined) {


### PR DESCRIPTION
## Summary

- New GoogleAdapter with 17 operations covering Calendar API + People API
- **Calendar**: list_calendars, list_events, get_event, create_event, update_event, delete_event, quick_add, freebusy
- **Contacts**: list_contacts, search_contacts, get_contact, create_contact, update_contact, delete_contact, list_contact_groups
- OAuth via Nango with `google-calendar` integration key
- Includes `raw_api` escape hatch for direct API access
- Add logo-fetcher agent for future integrations
- Import logos from mcp-hubby: Google, Spotify, Twitter, Gmail, LinkedIn, GitHub, CoinMarketCap

## Setup Required

1. **Google Cloud Console**: Enable Calendar API + People API, create OAuth credentials
2. **Nango**: Add `google-calendar` integration with scopes `calendar` + `contacts`
3. Service is in `beta` status until manually tested

## Test plan

- [ ] Connect Google account via /integrations
- [ ] Test `list_calendars` returns user's calendars
- [ ] Test `list_events` returns upcoming events
- [ ] Test `create_event` creates event visible in Google Calendar
- [ ] Test `search_contacts` finds contacts by name/email
- [ ] Verify OAuth refresh works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)