### PR TITLE
🛡️ Refine context drift detection to allow safe recovery operations

### DIFF
--- a/.vitest-only/README.md
+++ b/.vitest-only/README.md
@@ -1,0 +1,28 @@
+# Why This Directory Exists
+
+This project uses **Vitest** for testing, not Buntest.
+
+If you see this message, you probably ran `bun test` by mistake.
+
+## ✅ Correct Command
+
+```bash
+bun run test
+```
+
+## ❌ Wrong Command
+
+```bash
+bun test  # This won't work - we use Vitest, not Buntest
+```
+
+## Why?
+
+- `bun test` runs Buntest (Bun's native test runner)
+- `bun run test` runs Vitest (configured in vitest.config.mts)
+
+We've fully migrated to Vitest for better ecosystem support, mature tooling, and our
+PGlite database mocking setup.
+
+The `bunfig.toml` file points Buntest to this empty directory to fail fast if someone
+tries to run `bun test` accidentally.

--- a/__tests__/integration/lib/web-intelligence/parallel.integration.test.ts
+++ b/__tests__/integration/lib/web-intelligence/parallel.integration.test.ts
@@ -4,7 +4,7 @@
  * These tests make REAL API calls to Parallel's API.
  * They only run when PARALLEL_API_KEY is set in the environment.
  *
- * Run with: PARALLEL_API_KEY=your_key bun test -- --testPathPattern="integration"
+ * Run with: PARALLEL_API_KEY=your_key bun run test -- parallel.integration
  *
  * WARNING: These tests will consume API credits!
  */

--- a/__tests__/unit/app/api/connection/route.test.ts
+++ b/__tests__/unit/app/api/connection/route.test.ts
@@ -117,9 +117,9 @@ describe("POST /api/connection", () => {
         vi.restoreAllMocks();
     });
 
-    it.skip("returns 401 when not authenticated in production", async () => {
-        // Note: This test is skipped because process.env.NODE_ENV is read-only in bun test
-        // The behavior is tested manually and in e2e tests
+    it("returns 401 when not authenticated in production", async () => {
+        // Mock production environment
+        vi.stubEnv("NODE_ENV", "production");
         mocks.mockCurrentUser.mockResolvedValue(null);
 
         const request = new Request("http://localhost/api/connection", {
@@ -140,7 +140,7 @@ describe("POST /api/connection", () => {
         expect(response.status).toBe(401);
 
         const body = await response.json();
-        expect(body.error).toBe("Unauthorized");
+        expect(body.error).toBe("We need you to sign in first");
     });
 
     it("converts UIMessage format to ModelMessage and streams response", async () => {

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,9 @@
+# Bun configuration
+# https://bun.sh/docs/runtime/bunfig
+
+# We use Vitest for testing, not Buntest
+# This configuration prevents `bun test` from accidentally running
+[test]
+# Point to directory with no tests, forcing immediate failure
+# Always use: bun run test (which runs Vitest)
+root = "./.vitest-only"

--- a/knowledge/components/markdown-rendering.md
+++ b/knowledge/components/markdown-rendering.md
@@ -333,7 +333,7 @@ Use in messages:
 Unit tests cover all major functionality:
 
 ```bash
-bun test components/ui/markdown-renderer.test.tsx
+bun run test markdown-renderer
 ```
 
 **Test coverage**:


### PR DESCRIPTION
Extract dangerous git operations into dedicated function and allow read-only/navigation commands even when drift detected. This enables recovery from accidental context switches without blocking safe ops. Also migrate test runner docs from bun test to vitest.