### PR TITLE
🐛 Fix critical integration tools bug: userId/userEmail mismatch

### DIFF
--- a/__tests__/unit/lib/integrations/tools.test.ts
+++ b/__tests__/unit/lib/integrations/tools.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Integration Tools Factory Tests
+ *
+ * Critical test: Ensures getIntegrationTools correctly uses userEmail (not userId UUID)
+ * when querying for connected services and credentials.
+ *
+ * Bug history: Originally, tools.ts received dbUser.id (UUID) but all connection-manager
+ * functions expect userEmail. This caused integration tools to never load because database
+ * queries against userEmail column with UUID values returned no results.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { getIntegrationTools } from "@/lib/integrations/tools";
+import * as connectionManager from "@/lib/integrations/connection-manager";
+
+// Mock the connection manager module
+vi.mock("@/lib/integrations/connection-manager", () => ({
+    getConnectedServices: vi.fn(),
+    getCredentials: vi.fn(),
+}));
+
+describe("getIntegrationTools", () => {
+    const testUserEmail = "test@example.com";
+    const testUserId = "550e8400-e29b-41d4-a716-446655440000"; // UUID format
+
+    // Get mocked functions
+    const mockGetConnectedServices =
+        connectionManager.getConnectedServices as ReturnType<typeof vi.fn>;
+    const mockGetCredentials = connectionManager.getCredentials as ReturnType<
+        typeof vi.fn
+    >;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe("userEmail vs userId handling", () => {
+        it("should call getConnectedServices with userEmail, not userId UUID", async () => {
+            // Mock returning notion as connected service
+            mockGetConnectedServices.mockResolvedValue(["notion"]);
+
+            // Mock credentials lookup
+            mockGetCredentials.mockResolvedValue({
+                type: "oauth",
+                connectionId: "test-conn-id",
+                accountId: "test-account",
+                isDefault: true,
+            });
+
+            await getIntegrationTools(testUserEmail);
+
+            // CRITICAL ASSERTION: getConnectedServices must be called with email, not UUID
+            expect(mockGetConnectedServices).toHaveBeenCalledWith(testUserEmail);
+            expect(mockGetConnectedServices).not.toHaveBeenCalledWith(testUserId);
+        });
+
+        it("should call getCredentials with userEmail for each service", async () => {
+            mockGetConnectedServices.mockResolvedValue(["notion", "slack"]);
+            mockGetCredentials.mockResolvedValue({
+                type: "oauth",
+                connectionId: "test-conn-id",
+                accountId: "test-account",
+                isDefault: true,
+            });
+
+            await getIntegrationTools(testUserEmail);
+
+            // CRITICAL ASSERTION: getCredentials must be called with email
+            expect(mockGetCredentials).toHaveBeenCalledWith(testUserEmail, "notion");
+            expect(mockGetCredentials).toHaveBeenCalledWith(testUserEmail, "slack");
+            expect(mockGetCredentials).toHaveBeenCalledTimes(2);
+        });
+
+        it("should fail gracefully when passed a UUID instead of email", async () => {
+            // When called with UUID, the database query won't find matches
+            mockGetConnectedServices.mockResolvedValue([]);
+
+            const tools = await getIntegrationTools(testUserId);
+
+            // Should return empty tools object, not throw
+            expect(tools).toEqual({});
+            expect(mockGetConnectedServices).toHaveBeenCalledWith(testUserId);
+        });
+    });
+
+    describe("tool creation", () => {
+        it("should create tools for connected services with valid credentials", async () => {
+            mockGetConnectedServices.mockResolvedValue(["notion"]);
+            mockGetCredentials.mockResolvedValue({
+                type: "oauth",
+                connectionId: "test-conn-id",
+                accountId: "test-account",
+                isDefault: true,
+            });
+
+            const tools = await getIntegrationTools(testUserEmail);
+
+            expect(tools).toHaveProperty("notion");
+            expect(tools.notion).toBeDefined();
+        });
+
+        it("should skip services with credential errors", async () => {
+            mockGetConnectedServices.mockResolvedValue(["notion", "slack"]);
+
+            // First call (notion) succeeds, second call (slack) fails
+            mockGetCredentials
+                .mockResolvedValueOnce({
+                    type: "oauth",
+                    connectionId: "notion-conn-id",
+                    accountId: "notion-account",
+                    isDefault: true,
+                })
+                .mockRejectedValueOnce(new Error("Slack credentials expired"));
+
+            const tools = await getIntegrationTools(testUserEmail);
+
+            // Should have notion but not slack
+            expect(tools).toHaveProperty("notion");
+            expect(tools).not.toHaveProperty("slack");
+        });
+
+        it("should return empty object when no services connected", async () => {
+            mockGetConnectedServices.mockResolvedValue([]);
+
+            const tools = await getIntegrationTools(testUserEmail);
+
+            expect(tools).toEqual({});
+        });
+    });
+
+    describe("error handling", () => {
+        it("should handle getConnectedServices errors gracefully", async () => {
+            mockGetConnectedServices.mockRejectedValue(new Error("Database error"));
+
+            const tools = await getIntegrationTools(testUserEmail);
+
+            // Should return empty tools, not throw
+            expect(tools).toEqual({});
+        });
+    });
+});

--- a/app/api/connection/route.ts
+++ b/app/api/connection/route.ts
@@ -379,8 +379,9 @@ export async function POST(req: Request) {
 
         // Load integration tools for connected services
         // These are merged with built-in tools for the request
+        // CRITICAL: Pass userEmail, not dbUser.id (UUID) - connection-manager queries use email
         const integrationTools = modelSupportsTools
-            ? await getIntegrationTools(dbUser.id)
+            ? await getIntegrationTools(userEmail!)
             : {};
 
         // Merge built-in tools with integration tools

--- a/lib/integrations/tools.ts
+++ b/lib/integrations/tools.ts
@@ -83,7 +83,7 @@ const integrationToolSchema = z.object({
 /**
  * Create a tool for a connected service
  */
-function createServiceTool(service: ServiceDefinition, userId: string) {
+function createServiceTool(service: ServiceDefinition, userEmail: string) {
     const adapter = getAdapter(service.id);
     if (!adapter) {
         throw new Error(`No adapter found for service: ${service.id}`);
@@ -94,7 +94,7 @@ function createServiceTool(service: ServiceDefinition, userId: string) {
         inputSchema: integrationToolSchema,
         execute: async ({ action, params }) => {
             logger.info(
-                { service: service.id, action, userId },
+                { service: service.id, action, userEmail },
                 "Executing integration tool"
             );
 
@@ -112,7 +112,7 @@ function createServiceTool(service: ServiceDefinition, userId: string) {
 
             // Execute the actual operation
             try {
-                const response = await adapter.execute(action, params ?? {}, userId);
+                const response = await adapter.execute(action, params ?? {}, userEmail);
 
                 // Return the response content
                 // The adapter returns MCPToolResponse format, extract relevant parts
@@ -139,7 +139,7 @@ function createServiceTool(service: ServiceDefinition, userId: string) {
                 return { result: "Operation completed successfully" };
             } catch (error) {
                 logger.error(
-                    { error, service: service.id, action, userId },
+                    { error, service: service.id, action, userEmail },
                     "Integration tool execution failed"
                 );
 
@@ -162,9 +162,11 @@ type IntegrationTool = ReturnType<typeof createServiceTool>;
  *
  * Returns a Record of tool name → tool that can be spread into streamText's tools option.
  *
+ * @param userEmail - User's email address (NOT userId UUID - database queries use email)
+ *
  * @example
  * ```ts
- * const integrationTools = await getIntegrationTools(userId);
+ * const integrationTools = await getIntegrationTools(userEmail);
  * const result = await streamText({
  *     model: openrouter.chat(modelId),
  *     tools: { ...builtInTools, ...integrationTools },
@@ -173,13 +175,13 @@ type IntegrationTool = ReturnType<typeof createServiceTool>;
  * ```
  */
 export async function getIntegrationTools(
-    userId: string
+    userEmail: string
 ): Promise<Record<string, IntegrationTool>> {
     const tools: Record<string, IntegrationTool> = {};
 
     try {
         // Get user's connected services
-        const connectedServiceIds = await getConnectedServices(userId);
+        const connectedServiceIds = await getConnectedServices(userEmail);
 
         if (connectedServiceIds.length === 0) {
             return tools;
@@ -202,7 +204,7 @@ export async function getIntegrationTools(
 
             // Verify credentials exist and are valid
             try {
-                await getCredentials(userId, serviceId);
+                await getCredentials(userEmail, serviceId);
             } catch (error) {
                 logger.warn(
                     {
@@ -215,12 +217,15 @@ export async function getIntegrationTools(
             }
 
             // Create the tool
-            tools[serviceId] = createServiceTool(service, userId);
+            tools[serviceId] = createServiceTool(service, userEmail);
         }
 
-        logger.info({ userId, tools: Object.keys(tools) }, "Integration tools loaded");
+        logger.info(
+            { userEmail, tools: Object.keys(tools) },
+            "Integration tools loaded"
+        );
     } catch (error) {
-        logger.error({ error, userId }, "Failed to load integration tools");
+        logger.error({ error, userEmail }, "Failed to load integration tools");
     }
 
     return tools;


### PR DESCRIPTION
## Summary

Fixed critical bug preventing all integration tools (Notion, Slack, Google, etc.) from loading in the LLM context. The root cause was a userId/userEmail parameter mismatch that caused database queries to return no results.

### Impact
- **Before:** Users couldn't use any integrations (Notion, Slack, Google, etc.) through the chat interface
- **After:** All connected integrations now load correctly and are available to the LLM

### Root Cause
The system evolved from userId-based to userEmail-based database lookups, but `lib/integrations/tools.ts` wasn't updated:
- API route passed `dbUser.id` (UUID) to `getIntegrationTools()`
- Function parameter was named `userId` but should have been `userEmail`
- All connection-manager functions expect `userEmail` for database queries
- Result: `WHERE userEmail = '<uuid>'` returned zero rows

### Changes
1. **lib/integrations/tools.ts:**
   - Renamed parameter in `getIntegrationTools()` from `userId` to `userEmail`
   - Renamed parameter in `createServiceTool()` from `userId` to `userEmail`
   - Updated all internal references and logging

2. **app/api/connection/route.ts:**
   - Changed `getIntegrationTools(dbUser.id)` to `getIntegrationTools(userEmail!)`
   - Added comment explaining why userEmail (not UUID) is required

3. **__tests__/unit/lib/integrations/tools.test.ts:** (NEW)
   - Created comprehensive test suite with 7 test cases
   - Verifies userEmail (not userId UUID) is passed to connection-manager
   - Tests credential validation and error handling
   - Prevents regression

### Testing
- ✅ All 777 existing tests pass
- ✅ 7 new integration tools tests pass
- ✅ Pre-commit hooks pass (eslint, prettier, type-check)
- ✅ Pre-push hooks pass (full test suite + validation)

### Design Decisions Made Autonomously
- Used vitest mocking with proper type casting to avoid hoisting issues
- Placed test assertions to verify correct parameter passing (email vs UUID)
- Added explicit documentation in code comments about the userEmail requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)