### PR TITLE
✅ Add docs:sync to CI database setup job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,10 @@ jobs:
       - name: 🔧 TypeScript type checking
         run: pnpm run type-check
 
-  # Database Migration Tests
-  # Tests migrations against real PostgreSQL to catch ordering/constraint issues
-  migrations:
-    name: 🗄️ Migrations
+  # Database Setup Tests
+  # Tests migrations and docs sync against real PostgreSQL
+  database:
+    name: 🗄️ Database Setup
     runs-on: ubuntu-latest
     timeout-minutes: 5
 
@@ -86,6 +86,11 @@ jobs:
         run: |
           PGPASSWORD=postgres psql -h localhost -U postgres -d carmenta_test -c "\dt" | grep -E "users|conversations|messages|message_parts"
           echo "✅ All expected tables exist"
+
+      - name: 📚 Sync documentation to knowledge base
+        run: pnpm run docs:sync
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/carmenta_test
 
   # Unit Tests
   test:


### PR DESCRIPTION
## Summary
- Adds `docs:sync` step to CI workflow to test the full Render deploy flow
- Renames `migrations` job → `database` since it now tests migrations + docs sync
- Uses existing Postgres service—no additional infrastructure needed

## Test plan
- [ ] CI passes with the new docs:sync step
- [ ] Verify docs are synced to the `documents` table in test DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)