### PR TITLE
🐛 Fix Google Calendar testConnection to use Calendar API

### DIFF
--- a/__tests__/unit/lib/integrations/adapters/google-calendar-contacts.test.ts
+++ b/__tests__/unit/lib/integrations/adapters/google-calendar-contacts.test.ts
@@ -27,15 +27,12 @@ vi.mock("@/lib/http-client", () => ({
 vi.mock("@/lib/env", () => ({
     env: {
         NEXT_PUBLIC_APP_URL: "https://carmenta.ai",
-        NANGO_API_URL: "https://api.nango.dev",
-        NANGO_SECRET_KEY: "test-nango-key",
     },
 }));
 
 describe("GoogleCalendarContactsAdapter", () => {
     let adapter: GoogleCalendarContactsAdapter;
     const testUserEmail = "test@example.com";
-    const testConnectionId = "nango_test_google_123";
 
     beforeEach(() => {
         adapter = new GoogleCalendarContactsAdapter();


### PR DESCRIPTION
## Summary

- **Switch from People API to Calendar API** for connection verification - People API was returning 403 Forbidden because it requires separate enablement in Google Cloud Console, even when contacts scopes are granted
- **Add user-friendly error messages** for common failure scenarios instead of raw HTTP errors
- **Clean up unused imports** and Nango references from test mocks

## Test plan

- [ ] Verify Google Calendar Contacts integration test/verify works on production
- [ ] Check error messages display correctly when verification fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)