### PR TITLE
🔧 Improve knowledge base display and sync

### DIFF
--- a/components/knowledge-viewer/kb-content.tsx
+++ b/components/knowledge-viewer/kb-content.tsx
@@ -26,6 +26,7 @@ import * as Sentry from "@sentry/nextjs";
 import { cn } from "@/lib/utils";
 import { updateKBDocument, type KBDocument } from "@/lib/kb/actions";
 import { logger } from "@/lib/client-logger";
+import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 
 // Map paths to icons
 const PATH_ICONS: Record<string, typeof FileText> = {
@@ -310,8 +311,8 @@ export function KBContent({
                 )}
             </AnimatePresence>
 
-            {/* Content Area */}
-            <div className="relative flex-1 overflow-hidden">
+            {/* Content Area - uses absolute positioning to fill flex space */}
+            <div className="relative min-h-0 flex-1">
                 {isEditable ? (
                     <textarea
                         ref={textareaRef}
@@ -323,7 +324,7 @@ export function KBContent({
                         aria-describedby="character-count error-message"
                         aria-invalid={isOverLimit}
                         className={cn(
-                            "h-full w-full resize-none bg-transparent px-6 py-5",
+                            "absolute inset-0 resize-none bg-transparent px-6 py-5",
                             "font-sans text-[15px] leading-[1.7] text-foreground/80",
                             "placeholder:italic placeholder:text-foreground/30",
                             "focus:outline-none",
@@ -337,9 +338,12 @@ export function KBContent({
                         }}
                     />
                 ) : (
-                    <pre className="h-full w-full overflow-y-auto whitespace-pre-wrap px-6 py-5 font-sans text-[15px] leading-[1.7] text-foreground/80">
-                        {kbDocument.content}
-                    </pre>
+                    <div className="absolute inset-0 overflow-y-auto px-6 py-5">
+                        <MarkdownRenderer
+                            content={kbDocument.content}
+                            className="text-[15px] leading-[1.7] text-foreground/80"
+                        />
+                    </div>
                 )}
             </div>
 

--- a/components/knowledge-viewer/kb-sidebar.tsx
+++ b/components/knowledge-viewer/kb-sidebar.tsx
@@ -30,6 +30,11 @@ const FOLDER_ICONS: Record<string, typeof User> = {
     docs: BookOpen,
 };
 
+// Display names for folders (overrides capitalized path names)
+const FOLDER_DISPLAY_NAMES: Record<string, string> = {
+    docs: "Carmenta Documentation",
+};
+
 // Map document paths to icons
 const DOCUMENT_ICONS: Record<string, typeof FileText> = {
     "values.heart-centered": Heart,
@@ -104,7 +109,8 @@ export function KBSidebar({
                                 >
                                     <FolderIcon className="h-4 w-4 text-foreground/50" />
                                     <span className="flex-1 text-left font-medium capitalize text-foreground/80">
-                                        {folder.name}
+                                        {FOLDER_DISPLAY_NAMES[folder.path] ??
+                                            folder.name}
                                     </span>
                                     {!isExpanded && (
                                         <span className="rounded-full bg-foreground/10 px-1.5 py-0.5 text-xs text-foreground/50">

--- a/scripts/sync-docs.ts
+++ b/scripts/sync-docs.ts
@@ -96,6 +96,9 @@ interface DocFile {
     content: string;
 }
 
+// Files to exclude from syncing (AI coding config files that shouldn't be in KB)
+const EXCLUDED_FILES = ["CLAUDE.md", "AGENTS.md", "CURSOR.md"];
+
 /**
  * Recursively find all markdown files in a directory
  */
@@ -114,7 +117,11 @@ function findMarkdownFiles(dir: string, baseDir: string = dir): DocFile[] {
 
         if (entry.isDirectory()) {
             files.push(...findMarkdownFiles(fullPath, baseDir));
-        } else if (entry.isFile() && entry.name.endsWith(".md")) {
+        } else if (
+            entry.isFile() &&
+            entry.name.endsWith(".md") &&
+            !EXCLUDED_FILES.includes(entry.name)
+        ) {
             const relativePath = path.relative(baseDir, fullPath);
             // Convert path/to/file.md → docs.path.to.file
             const kbPath =


### PR DESCRIPTION
## Summary

- Exclude AI config files (CLAUDE.md, AGENTS.md, CURSOR.md) from docs sync - these were incorrectly being synced into the knowledge base
- Render non-editable documents with MarkdownRenderer instead of plain `<pre>` text - system docs now display with proper markdown formatting
- Fix textarea height to fill available space using absolute positioning pattern
- Rename "Docs" folder to "Carmenta Documentation" in sidebar

## Test plan

- [ ] Run `pnpm docs:sync` and verify CLAUDE.md is not synced
- [ ] View a system doc in knowledge base and confirm markdown renders properly
- [ ] Edit a profile document and verify textarea fills the available height
- [ ] Check sidebar shows "Carmenta Documentation" instead of "Docs"

🤖 Generated with [Claude Code](https://claude.com/claude-code)