### PR TITLE
🐛 Fix Dropbox OAuth callback 400 error

### DIFF
--- a/lib/integrations/oauth/providers/dropbox.ts
+++ b/lib/integrations/oauth/providers/dropbox.ts
@@ -59,6 +59,8 @@ export const dropboxProvider: OAuthProviderConfig = {
                         Authorization: `Bearer ${accessToken}`,
                         "Content-Type": "application/json",
                     },
+                    // Dropbox RPC endpoints with no parameters need literal string "null"
+                    body: "null",
                 })
                 .json<{
                     account_id: string;


### PR DESCRIPTION
## Summary
- Dropbox RPC endpoints with no parameters require a literal string `"null"` as the body
- Without this, the Dropbox API returns 400 Bad Request during OAuth callback
- Pattern matches mcp-hubby reference implementation and existing Dropbox adapter usage

## Test plan
- [x] Tests pass
- [x] Type check passes
- [ ] Deploy and test Dropbox OAuth flow on live site

🤖 Generated with [Claude Code](https://claude.com/claude-code)