### PR TITLE
✨ Wire up tool-ui components to chat tool renderer

### DIFF
--- a/components/generative-ui/poi-map-wrapper.tsx
+++ b/components/generative-ui/poi-map-wrapper.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * POIMapWrapper - Stateful wrapper for POIMap in chat context
+ *
+ * The POIMap component requires external state management for display mode,
+ * widget state (selection, favorites, viewport), and theme. This wrapper
+ * provides that state management for use in the chat tool renderer.
+ */
+
+import { useState, useCallback } from "react";
+import { useTheme } from "next-themes";
+import { POIMap } from "@/components/tool-ui/poi-map";
+import type {
+    POI,
+    POIMapViewState,
+    MapCenter,
+    POICategory,
+} from "@/components/tool-ui/poi-map/schema";
+import { DEFAULT_CENTER, DEFAULT_ZOOM } from "@/components/tool-ui/poi-map/schema";
+
+type DisplayMode = "inline" | "pip" | "fullscreen" | "carousel";
+
+interface View {
+    mode: "modal" | "inline";
+    params: Record<string, unknown> | null;
+}
+
+export interface POIMapWrapperProps {
+    id: string;
+    pois: POI[];
+    initialCenter?: MapCenter;
+    initialZoom?: number;
+    title?: string;
+    className?: string;
+}
+
+export function POIMapWrapper({
+    id,
+    pois,
+    initialCenter,
+    initialZoom,
+    title,
+    className,
+}: POIMapWrapperProps) {
+    const { resolvedTheme } = useTheme();
+    const theme = resolvedTheme === "dark" ? "dark" : "light";
+
+    // Display mode state - start inline, can expand to fullscreen
+    const [displayMode, setDisplayMode] = useState<DisplayMode>("inline");
+
+    // Modal view state for POI details
+    const [view, setView] = useState<View | null>(null);
+
+    // Widget state for map viewport, selection, favorites
+    const [widgetState, setWidgetState] = useState<POIMapViewState>({
+        selectedPoiId: null,
+        favoriteIds: [],
+        mapCenter: initialCenter ?? DEFAULT_CENTER,
+        mapZoom: initialZoom ?? DEFAULT_ZOOM,
+        categoryFilter: null,
+    });
+
+    const handleWidgetStateChange = useCallback((partial: Partial<POIMapViewState>) => {
+        setWidgetState((prev) => ({ ...prev, ...partial }));
+    }, []);
+
+    const handleRequestDisplayMode = useCallback((mode: DisplayMode) => {
+        setDisplayMode(mode);
+    }, []);
+
+    const handleViewDetails = useCallback((poiId: string) => {
+        setView({ mode: "modal", params: { poiId } });
+    }, []);
+
+    const handleDismissModal = useCallback(() => {
+        setView(null);
+    }, []);
+
+    const handleToggleFavorite = useCallback((poiId: string, isFavorite: boolean) => {
+        setWidgetState((prev) => {
+            const newFavorites = isFavorite
+                ? [...prev.favoriteIds, poiId]
+                : prev.favoriteIds.filter((id) => id !== poiId);
+            return { ...prev, favoriteIds: newFavorites };
+        });
+    }, []);
+
+    const handleFilterCategory = useCallback((category: POICategory | null) => {
+        setWidgetState((prev) => ({ ...prev, categoryFilter: category }));
+    }, []);
+
+    // Fullscreen mode needs a fixed container
+    if (displayMode === "fullscreen") {
+        return (
+            <div className="fixed inset-0 z-50 bg-background">
+                <POIMap
+                    id={id}
+                    pois={pois}
+                    initialCenter={initialCenter}
+                    initialZoom={initialZoom}
+                    title={title}
+                    className="h-full w-full"
+                    displayMode={displayMode}
+                    widgetState={widgetState}
+                    theme={theme}
+                    view={view}
+                    onWidgetStateChange={handleWidgetStateChange}
+                    onRequestDisplayMode={handleRequestDisplayMode}
+                    onToggleFavorite={handleToggleFavorite}
+                    onFilterCategory={handleFilterCategory}
+                    onViewDetails={handleViewDetails}
+                    onDismissModal={handleDismissModal}
+                />
+            </div>
+        );
+    }
+
+    return (
+        <div className={className} style={{ height: "320px" }}>
+            <POIMap
+                id={id}
+                pois={pois}
+                initialCenter={initialCenter}
+                initialZoom={initialZoom}
+                title={title}
+                className="h-full w-full"
+                displayMode={displayMode}
+                widgetState={widgetState}
+                theme={theme}
+                view={view}
+                onWidgetStateChange={handleWidgetStateChange}
+                onRequestDisplayMode={handleRequestDisplayMode}
+                onToggleFavorite={handleToggleFavorite}
+                onFilterCategory={handleFilterCategory}
+                onViewDetails={handleViewDetails}
+                onDismissModal={handleDismissModal}
+            />
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Connect the ported tool-ui components (Plan, LinkPreview, OptionList, POIMap) to the ToolPartRenderer in holo-thread.tsx. These rich interactive components were previously implemented but not connected to the rendering system.

## Components Wired

### Plan
- Shows task progress with status icons, progress bar, collapsible details
- Perfect for visualizing AI task workflows (maps to TodoWrite-style data)
- Supports tool names: `plan`, `taskPlan`
- UX: Progress bar animates as tasks complete, in-progress items have spinning icons, completed items show checkmarks

### LinkPreview  
- Rich URL cards with Open Graph data (image, title, description, favicon)
- Clickable cards that open URLs in new tabs
- Supports tool names: `linkPreview`, `previewLink`
- UX: Loading skeleton while fetching, hover effects, graceful fallbacks

### OptionList
- Interactive selection UI with checkboxes (multi) or radio buttons (single)
- Shows confirmation receipt after selection
- Supports tool names: `optionList`, `selectOption`, `presentOptions`
- UX: Keyboard navigation, selection validation, Clear/Confirm actions

### POIMap
- Interactive location maps with markers, list view, favorites, category filtering
- Fullscreen mode with sidebar list
- Supports tool names: `poiMap`, `showLocations`, `mapLocations`
- UX: Click to expand fullscreen, favorite locations, filter by category, modal details

## Implementation Details

- Added cases to ToolPartRenderer switch statement following existing patterns
- Created `POIMapWrapper` component to manage required state (display mode, widget state, theme)
- Each component handles loading, error, and empty states gracefully
- All components wrapped with ToolWrapper for consistent status/debug UI

## Test Plan

- [x] TypeScript compilation passes
- [x] ESLint passes (no new warnings in changed files)
- [x] Prettier formatting applied
- [x] All 1422 unit/integration tests pass
- [ ] Manual testing with tool calls that return plan/linkPreview/optionList/poiMap data

🤖 Generated with [Claude Code](https://claude.com/claude-code)