### PR TITLE
🐛 Fix immutability violations in tool progress state

### DIFF
--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -353,8 +353,6 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
             if (status === "running") {
                 const progressState = createInitialProgressState(toolName);
                 if (progressState) {
-                    // Add search query as context
-                    progressState.context = (input?.query as string) ?? undefined;
                     return (
                         <ToolWrapper
                             toolName={toolName}
@@ -362,7 +360,12 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                             status={status}
                             input={input}
                         >
-                            <ToolProgress progress={progressState} />
+                            <ToolProgress
+                                progress={{
+                                    ...progressState,
+                                    context: (input?.query as string) ?? undefined,
+                                }}
+                            />
                         </ToolWrapper>
                     );
                 }
@@ -397,8 +400,6 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
             if (status === "running") {
                 const progressState = createInitialProgressState(toolName);
                 if (progressState) {
-                    // Add URL as context
-                    progressState.context = (input?.url as string) ?? undefined;
                     return (
                         <ToolWrapper
                             toolName={toolName}
@@ -406,7 +407,12 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                             status={status}
                             input={input}
                         >
-                            <ToolProgress progress={progressState} />
+                            <ToolProgress
+                                progress={{
+                                    ...progressState,
+                                    context: (input?.url as string) ?? undefined,
+                                }}
+                            />
                         </ToolWrapper>
                     );
                 }
@@ -436,8 +442,6 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
             if (status === "running") {
                 const progressState = createInitialProgressState(toolName);
                 if (progressState) {
-                    // Add research objective as context
-                    progressState.context = (input?.objective as string) ?? undefined;
                     return (
                         <ToolWrapper
                             toolName={toolName}
@@ -445,7 +449,12 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                             status={status}
                             input={input}
                         >
-                            <ToolProgress progress={progressState} />
+                            <ToolProgress
+                                progress={{
+                                    ...progressState,
+                                    context: (input?.objective as string) ?? undefined,
+                                }}
+                            />
                         </ToolWrapper>
                     );
                 }


### PR DESCRIPTION
## Summary

Fixes React immutability violations in tool progress rendering that were introduced when PR #288 was merged. The merged code was mutating `progressState` objects after creation, which violates React's immutability principle and could cause bugs.

## What Changed

Changed from mutating the state object:
```typescript
progressState.context = value;
<ToolProgress progress={progressState} />
```

To using immutable object spread:
```typescript
<ToolProgress progress={{...progressState, context: value}} />
```

Affects three tool types:
- webSearch (adds query as context)
- fetchPage (adds URL as context)
- deepResearch (adds objective as context)

## Why This Matters

React expects state objects to be immutable. Mutating them after creation can lead to:
- Unexpected rendering behavior
- Stale closures in effects/callbacks
- Difficult-to-debug issues in production

## History

This fix was originally in commit 10699ac but was pushed to the `feat/streaming-tool-progress` branch after PR #288 was already merged, so it didn't make it into main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)