### PR TITLE
⚙️ Configure Streamdown with proper props for code blocks

### DIFF
--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -1281,7 +1281,10 @@ function AssistantMessage({
                             {hasContent && (
                                 <div className="group">
                                     <div className="px-4 pb-2 pt-4">
-                                        <MarkdownRenderer content={content} />
+                                        <MarkdownRenderer
+                                            content={content}
+                                            isStreaming={isStreaming}
+                                        />
                                     </div>
                                     <div className="px-4 pb-1">
                                         <MessageActions
@@ -1307,7 +1310,7 @@ function AssistantMessage({
                     </div>
 
                     <div className="assistant-message-bubble rounded-2xl rounded-bl-md border-l-[3px] border-l-cyan-400 px-4 py-4">
-                        <MarkdownRenderer content={content} />
+                        <MarkdownRenderer content={content} isStreaming={isStreaming} />
                     </div>
                     <MessageActions
                         content={content}

--- a/components/ui/markdown-renderer.tsx
+++ b/components/ui/markdown-renderer.tsx
@@ -12,6 +12,8 @@ interface MarkdownRendererProps {
     className?: string;
     /** Inline mode - removes paragraph margins for compact display */
     inline?: boolean;
+    /** Whether content is actively streaming (disables copy/download buttons) */
+    isStreaming?: boolean;
 }
 
 /**
@@ -20,10 +22,23 @@ interface MarkdownRendererProps {
  * Uses Streamdown (Vercel's AI-optimized markdown renderer) for streaming-aware
  * parsing. Handles incomplete markdown syntax gracefully during streaming.
  *
- * Supports GitHub Flavored Markdown (tables, strikethrough, task lists).
+ * Features:
+ * - GitHub Flavored Markdown (tables, strikethrough, task lists)
+ * - Shiki syntax highlighting with github-light/dark themes
+ * - Built-in copy & download buttons for code blocks
+ * - KaTeX math rendering (lazy-loaded when $$ detected)
+ * - Mermaid diagram support
+ *
+ * The `isStreaming` prop disables interactive buttons during active streaming
+ * to prevent copying incomplete content.
  */
 export const MarkdownRenderer = memo(
-    ({ content, className, inline = false }: MarkdownRendererProps) => {
+    ({
+        content,
+        className,
+        inline = false,
+        isStreaming = false,
+    }: MarkdownRendererProps) => {
         return (
             <div
                 className={cn(
@@ -32,14 +47,17 @@ export const MarkdownRenderer = memo(
                     className
                 )}
             >
-                <Streamdown>{content}</Streamdown>
+                <Streamdown mode="streaming" isAnimating={isStreaming} controls={true}>
+                    {content}
+                </Streamdown>
             </div>
         );
     },
     (prev, next) =>
         prev.content === next.content &&
         prev.className === next.className &&
-        prev.inline === next.inline
+        prev.inline === next.inline &&
+        prev.isStreaming === next.isStreaming
 );
 
 MarkdownRenderer.displayName = "MarkdownRenderer";


### PR DESCRIPTION
## Summary

- Properly configure Streamdown component to unlock its built-in features
- Add `isStreaming` prop to disable copy/download buttons during active streaming
- Pass `mode="streaming"` and `controls={true}` explicitly to Streamdown
- Update assistant message rendering in holo-thread.tsx to pass isStreaming

This addresses part of #297 by enabling Streamdown's built-in code block controls (copy, download with proper file extensions, Shiki syntax highlighting) that were previously unused because we were only passing content as children.

## What This Enables

Streamdown's code block now has:
- ✅ Copy button with 2s feedback (disabled during streaming)
- ✅ Download button with proper file extension mapping (300+ languages)
- ✅ Shiki syntax highlighting with github-light/dark themes
- ✅ Language label in header

## What Was Wrong

```tsx
// Before - bare minimum, not using any features
<Streamdown>{content}</Streamdown>

// After - properly configured
<Streamdown
  mode="streaming"
  isAnimating={isStreaming}
  controls={true}
>
  {content}
</Streamdown>
```

## Test Plan

- [x] TypeScript compiles without errors
- [x] ESLint passes on changed files
- [x] All 1460 tests pass
- [ ] Manual verification: Code blocks show copy/download buttons
- [ ] Manual verification: Buttons are disabled during streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)