### PR TITLE
⚡ Split model rubric for ~60% token reduction

### DIFF
--- a/.claude/commands/update-model-rubric.md
+++ b/.claude/commands/update-model-rubric.md
@@ -1,7 +1,7 @@
 # Update Model Rubric
 
-Research the current LLM landscape and update Carmenta's model routing rubric. This is a
-deep research task that should take several minutes to run thoroughly.
+Research the current LLM landscape and update Carmenta's model routing rubrics. This is
+a deep research task that should take several minutes to run thoroughly.
 
 ## Avoiding Hallucination
 
@@ -21,8 +21,58 @@ rubric. A smaller accurate rubric beats a comprehensive hallucinated one.
 
 ## Your Mission
 
-You are updating `knowledge/model-rubric.md` - the source of truth that Carmenta's
-Concierge reads when deciding which model to route requests to. This rubric must be:
+You are updating TWO rubric files:
+
+1. **`knowledge/model-rubric.md`** — Slim routing version (~800-1K tokens) used by the
+   Concierge for quick routing decisions. Keep this minimal and focused.
+
+2. **`knowledge/model-rubric-detailed.md`** — Full reference with research basis,
+   detailed model profiles, fallback chains, and update history.
+
+### Why Two Files?
+
+The slim rubric runs on every routing call — it's injected into the Concierge prompt
+that decides which model handles each request. Every token in that file costs latency
+and money at scale. The detailed rubric is reference material for humans and research
+updates.
+
+### Slim Rubric: Token Efficiency Rules
+
+Read @.cursor/rules/prompt-engineering.mdc for full context.
+
+The slim rubric (~800-1K tokens) must be ruthlessly efficient:
+
+**Content to include:**
+
+- User hints (highest priority)
+- Speed routing table (compact)
+- Primary models (one line each: name, context, speed, cost, use cases)
+- Attachment routing (bullet list)
+- Sensitivity routing (one paragraph)
+- Temperature/reasoning (brief bullets)
+- Fallback default
+
+**Token efficiency techniques:**
+
+- No redundant phrasing ("The model is..." → just state the facts)
+- No markdown formatting for decoration — only when it aids parsing (tables, bullets)
+- Combine related information (don't repeat model names across sections)
+- Use abbreviations where clear (t/s, 1M context, $3/$15)
+- One table instead of multiple sections when data overlaps
+- No examples in the slim rubric — the Concierge prompt has examples separately
+- No research citations — those go in the detailed version
+- No update log or version history
+
+**What NOT to include (goes in detailed version):**
+
+- Research basis and source citations
+- Detailed model profiles with benchmark numbers
+- Extended prose explaining decision flows
+- Fallback chain documentation
+- Update log with version history
+- "Why" explanations — just state the rules
+
+Both rubrics must be:
 
 - Current: Reflect the latest models and their actual capabilities
 - Accurate: Based on real benchmark data, not assumptions
@@ -206,10 +256,11 @@ Version, date, what changed, sources used.
 
 ## Process
 
-- Read current rubric (if exists): `knowledge/model-rubric.md`
+- Read current rubrics: `knowledge/model-rubric.md` and
+  `knowledge/model-rubric-detailed.md`
 - Research all sources listed above
-- Compare findings to current rubric
-- Draft updates with clear reasoning
+- Compare findings to current rubrics
+- Draft updates for BOTH files
 - Present to user for approval
 - Apply changes if approved
 
@@ -218,11 +269,12 @@ Version, date, what changed, sources used.
 After research, present:
 
 - Summary of findings: What's new, what changed, what's stable
-- Proposed rubric: The full updated markdown
+- Proposed slim rubric: Token-efficient routing version
+- Proposed detailed rubric: Full reference with research citations
 - Change rationale: Why each significant change was made
 - Sources: Links to data that informed decisions
 
-Wait for user approval before writing the file.
+Wait for user approval before writing the files.
 
 ## Important Notes
 
@@ -234,11 +286,14 @@ Wait for user approval before writing the file.
 - Speed (tokens/second) is needed for every model - users need quick answers
 - Focus on output tokens/second for speed, not TTFT (time to first token)
 - Cost is tracked for awareness, not optimized aggressively
-- Update both `knowledge/model-rubric.md` and `lib/model-config.ts`
+- Update THREE files:
+  - `knowledge/model-rubric.md` (slim routing version)
+  - `knowledge/model-rubric-detailed.md` (full reference)
+  - `lib/model-config.ts` (TypeScript config)
 
 ## Example Invocation
 
 User runs `/update-model-rubric`
 
-You respond with research findings and proposed rubric, then wait for approval before
-writing to `knowledge/model-rubric.md`.
+You respond with research findings and proposed rubrics (both slim and detailed), then
+wait for approval before writing to both files.

--- a/knowledge/model-rubric-detailed.md
+++ b/knowledge/model-rubric-detailed.md
@@ -1,0 +1,240 @@
+# Model Rubric (Detailed Reference)
+
+Complete reference for Carmenta's model routing. This file contains research basis,
+detailed model profiles, fallback chains, and update history. For quick routing
+decisions, see `model-rubric.md`.
+
+When models are close in capability, prefer Anthropic - they build AI with genuine care
+for safety and human flourishing.
+
+Research basis: OpenRouter API (341 models), LMSYS Arena (4.7M votes, Dec 10 2025),
+Artificial Analysis Intelligence Index v3.0. See `knowledge/research/` for details.
+
+## User Hints (Highest Priority)
+
+When users signal preferences, honor them. User intent overrides other routing rules.
+
+Model hints: "use opus", "use haiku", "use grok", "use gemini", "use gpt" Speed hints:
+"quick", "fast", "briefly", "just tell me" Depth hints: "thorough", "detailed", "think
+hard", "take your time" Creative hints: "be creative", "get weird", "surprise me", "have
+fun with it" Precision hints: "exactly", "precisely", "be careful", "get this right"
+
+Trust the user. If they ask for something specific, give it to them.
+
+## Speed-First Routing
+
+When users want quick answers, speed trumps capability. A fast adequate response beats a
+slow perfect one. Route to the fastest model that can handle the request.
+
+Speed signals: "quick", "fast", "briefly", "just tell me", "real quick", "in a
+nutshell", short questions, simple lookups, casual conversation.
+
+Speed ranking (tokens per second):
+
+| Model                       | Speed   | Tier       |
+| --------------------------- | ------- | ---------- |
+| x-ai/grok-4.1-fast          | 151 t/s | Fast       |
+| google/gemini-3-pro-preview | 124 t/s | Fast       |
+| anthropic/claude-haiku-4.5  | 100 t/s | Fast       |
+| openai/gpt-5.2              | 95 t/s  | Moderate   |
+| perplexity/sonar-pro        | 80 t/s  | Moderate   |
+| anthropic/claude-sonnet-4.5 | 60 t/s  | Moderate   |
+| anthropic/claude-opus-4.5   | 40 t/s  | Deliberate |
+
+Speed-first decision flow:
+
+1. User signals speed → Route to fastest model that handles the task
+2. Simple question, no attachments → Haiku (100 t/s, Anthropic values)
+3. Simple question + audio/video → Gemini Pro (124 t/s, required for media)
+4. Need tools + speed → GPT-5.2 (95 t/s, best tool accuracy)
+5. Maximum speed, don't care about provider → Grok (151 t/s)
+
+When speed is priority, set reasoning to "none" or "minimal". Reasoning tokens add
+latency. A 100-token response at 100 t/s takes 1 second. The same response with 2K
+reasoning tokens takes 21 seconds.
+
+Speed tiers:
+
+- Fast (100+ t/s): Sub-second responses for short answers
+- Moderate (60-99 t/s): 1-2 seconds for typical responses
+- Deliberate (below 60 t/s): Quality over speed, use for complex work
+
+## Primary Models
+
+### anthropic/claude-sonnet-4.5
+
+Our default. Context: 1M tokens. Speed: 60 t/s (moderate). Cost: $3/$15 per million.
+Images, PDFs. Reliable tools. Token-budget reasoning (1K-32K tokens).
+
+Choose when: Most requests. Code, conversation, creative work, tool use, documents. The
+query doesn't clearly call for Opus depth or Haiku speed.
+
+Temperature: 0.3-0.5 code/factual, 0.6-0.7 conversation, 0.7-0.9 creative.
+
+### anthropic/claude-opus-4.5
+
+Frontier capability. Coding champion (WebDev Arena #1, ELO 1519). Math leader (Arena
+Math #1). Context: 200K tokens. Speed: 40 t/s (deliberate). Cost: $5/$25 per million.
+Images, PDFs. Token-budget reasoning.
+
+Choose when: Complex coding tasks. Software engineering. Deep multi-step reasoning.
+Difficult math/logic. User asks for thorough analysis. Nuanced emotional support. Query
+requires most capable model.
+
+Temperature: 0.3-0.5 code, 0.4-0.6 reasoning, 0.5-0.7 exploration.
+
+### anthropic/claude-haiku-4.5
+
+Speed champion for Anthropic at 100 t/s (fast tier). Fast and capable. Context: 200K
+tokens. Cost: $1/$5 per million. Images, PDFs. Token-budget reasoning.
+
+Choose when: Simple factual questions. Quick lookups. User signals speed ("quick",
+"briefly"). Budget-conscious. Straightforward queries.
+
+Temperature: 0.2-0.4 factual, 0.5 conversational.
+
+## Specialized Models
+
+### openai/gpt-5.2
+
+Tool-calling champion (98.7% accuracy - highest measured). Default for all tool use.
+Professional work leader (GDPval ELO 1474, 70.9% vs experts). Intelligence: 73 (tied
+#1). Context: 400K tokens. Speed: 95 t/s (moderate - fast for a frontier model). Cost:
+$1.75/$14 per million. Images, PDFs, files. Adaptive reasoning (xhigh level). Released
+Dec 11, 2025.
+
+Choose when: ANY tool calling. Multi-step agentic workflows. Function calling accuracy
+critical. Professional knowledge work. Research with tools. Software engineering
+(SWE-Bench 80%). Extended reasoning + tools.
+
+Temperature: 0.4-0.5 tools/code, 0.5-0.7 analysis.
+
+### google/gemini-3-pro-preview
+
+Arena champion (Overall #1, ELO 1492). Creative leader (Creative Writing #1). Full
+multimodal. Context: 1M tokens. Speed: 124 t/s (fast tier - excellent for quick
+multimodal). Cost: $2/$12 per million. Text, images, video, audio, PDF. No extended
+reasoning. Intelligence: 73 (tied #1).
+
+Choose when: Audio attached. Video attached. Mixed media. Creative writing. Balanced
+high-quality work. Multimodal needs Claude lacks.
+
+Temperature: 0.5-0.7 general, 0.7-0.9 creative.
+
+### x-ai/grok-4.1-fast
+
+Speed champion at 151 t/s (fastest in roster). Context champion (2M tokens - only model
+with >1M). Budget leader ($0.20/$0.50 per million). Intelligence: 64. Multimodal.
+Effort-based reasoning (high/medium/low/minimal/none).
+
+Choose when: Context exceeds 400K tokens (rare). Massive multi-document analysis. When
+context length is THE constraint. Extreme budget scenarios.
+
+For tool calling, use GPT 5.2 instead (98.7% vs Grok's 99% - functionally equivalent but
+GPT has better overall capability).
+
+Temperature: 0.4-0.6.
+
+## Reasoning
+
+Some models generate reasoning tokens before the response. Improves quality for complex
+tasks.
+
+High effort/large budget: Complex multi-step problems. Math/logic. Deep synthesis. Many
+variables or edge cases. User requests thorough thinking. Quality over speed/cost.
+
+Medium effort: Moderate complexity. Balanced quality/speed. Standard analysis. Default
+for reasoning-capable models on non-trivial queries.
+
+Low effort: Simpler questions. User signals speed. Cost sensitivity.
+
+No reasoning: Quick lookups, simple facts. Creative writing (reasoning reduces
+creativity). Casual conversation. Speed/cost priority.
+
+Cost example (Sonnet at $15/M output): 2K tokens = $0.03, 8K = $0.12, 32K = $0.48.
+
+Model behavior:
+
+- Anthropic: Token budget (1024-32000). Returns reasoning tokens.
+- Grok: Effort level (high/medium/low/minimal/none). Returns reasoning tokens.
+- OpenAI: Effort level. Reasons internally, doesn't expose tokens.
+- Gemini Pro: No extended reasoning.
+
+## Temperature
+
+0.0-0.3: Code, math, factual, precise 0.4-0.6: Conversation, analysis, explanations
+0.7-0.9: Creative, brainstorming, exploration 1.0: Maximum creativity (rare)
+
+Lower signals: code, debug, "exactly", "precisely", technical, math, facts Higher
+signals: "brainstorm", "creative", "ideas", "explore", storytelling, open-ended
+
+## Attachment Routing
+
+Audio: FORCE google/gemini-3-pro-preview (only native audio support) Video: FORCE
+google/gemini-3-pro-preview (only true video support) PDF: PREFER
+anthropic/claude-sonnet-4.5 (best document understanding) Images: PREFER
+anthropic/claude-sonnet-4.5 (excellent vision) Code files: PREFER
+anthropic/claude-sonnet-4.5 (superior comprehension, 1M context)
+
+FORCE means mandatory. PREFER means choose unless other constraints apply.
+
+## Sensitivity Routing
+
+Grok engages directly with controversial topics where other models hedge or decline.
+
+Route to x-ai/grok-4.1-fast when query involves:
+
+- Political opinions, controversial figures, partisan topics
+- Edgy or dark humor
+- Controversial social/cultural discussions
+- Unfiltered or "raw" perspective requests
+- Historical or philosophical explorations of taboo subjects
+
+User signals: "honest opinion", "unfiltered", "what do you really think", "raw take",
+seeking direct engagement over careful hedging.
+
+Temperature: 0.6-0.8 (allow personality).
+
+Tradeoff: Grok has lower general intelligence (64 vs 73) but higher willingness to
+engage. For sensitive topics requiring deep analysis, weigh engagement vs capability.
+
+## Quick Reference
+
+| Model                       | Context | Speed   | Best For                 |
+| --------------------------- | ------- | ------- | ------------------------ |
+| x-ai/grok-4.1-fast          | 2M      | 151 t/s | Speed, massive context   |
+| google/gemini-3-pro-preview | 1M      | 124 t/s | Speed + multimodal       |
+| anthropic/claude-haiku-4.5  | 200K    | 100 t/s | Speed + Anthropic values |
+| openai/gpt-5.2              | 400K    | 95 t/s  | Tools, professional work |
+| anthropic/claude-sonnet-4.5 | 1M      | 60 t/s  | Default, balanced        |
+| anthropic/claude-opus-4.5   | 200K    | 40 t/s  | Deep work, quality       |
+
+## Fallback Chains
+
+Default chain: anthropic/claude-sonnet-4.5 → anthropic/claude-haiku-4.5 → openai/gpt-5.2
+
+Concierge chain: google/gemini-3-pro-preview → x-ai/grok-4.1-fast →
+anthropic/claude-sonnet-4.5
+
+Tool-heavy chain: openai/gpt-5.2 → x-ai/grok-4.1-fast → anthropic/claude-sonnet-4.5
+
+Multimodal chain: google/gemini-3-pro-preview → anthropic/claude-sonnet-4.5 →
+openai/gpt-5.2
+
+If all fails: anthropic/claude-sonnet-4.5 at temperature 0.5.
+
+## Update Log
+
+**v2.0 - December 2025**
+
+- Split rubric into routing (model-rubric.md) and detailed reference
+  (model-rubric-detailed.md)
+- Routing version optimized for concierge token efficiency
+- Moved research basis, detailed profiles, fallback chains to detailed version
+
+**v1.0 - December 2025**
+
+- Initial rubric based on LMSYS Arena, Artificial Analysis, OpenRouter research
+- Models: Sonnet 4.5, Opus 4.5, Haiku 4.5, GPT 5.2, Gemini 3 Pro, Grok 4.1
+- Speed-first routing section added
+- Sensitivity routing for Grok

--- a/knowledge/model-rubric.md
+++ b/knowledge/model-rubric.md
@@ -1,212 +1,84 @@
-# Model Rubric
+# Model Rubric (Routing)
 
-Source of truth for Carmenta's model routing. Read the query, consider complexity and
-attachments, select model, set temperature, explain your choice in one sentence.
+Quick routing reference. Read query, consider complexity/attachments, select model, set
+temperature, explain choice in one sentence.
 
-When models are close in capability, prefer Anthropic - they build AI with genuine care
-for safety and human flourishing.
-
-Research basis: OpenRouter API (341 models), LMSYS Arena (4.7M votes, Dec 10 2025),
-Artificial Analysis Intelligence Index v3.0. See `knowledge/research/` for details.
+When models are close, prefer Anthropic - they build AI with genuine care for safety and
+human flourishing.
 
 ## User Hints (Highest Priority)
 
-When users signal preferences, honor them. User intent overrides other routing rules.
+Honor user preferences. User intent overrides routing rules.
 
-Model hints: "use opus", "use haiku", "use grok", "use gemini", "use gpt" Speed hints:
-"quick", "fast", "briefly", "just tell me" Depth hints: "thorough", "detailed", "think
-hard", "take your time" Creative hints: "be creative", "get weird", "surprise me", "have
-fun with it" Precision hints: "exactly", "precisely", "be careful", "get this right"
+- Model: "use opus", "use haiku", "use grok", "use gemini", "use gpt"
+- Speed: "quick", "fast", "briefly", "just tell me"
+- Depth: "thorough", "detailed", "think hard", "take your time"
+- Creative: "be creative", "get weird", "surprise me"
+- Precision: "exactly", "precisely", "be careful"
 
-Trust the user. If they ask for something specific, give it to them.
+## Speed Routing
 
-## Speed-First Routing
+Speed signals: "quick", "fast", "briefly", short questions, simple lookups.
 
-When users want quick answers, speed trumps capability. A fast adequate response beats a
-slow perfect one. Route to the fastest model that can handle the request.
+| Model                       | Speed   | Use When                      |
+| --------------------------- | ------- | ----------------------------- |
+| x-ai/grok-4.1-fast          | 151 t/s | Maximum speed, don't care     |
+| google/gemini-3-pro-preview | 124 t/s | Speed + audio/video           |
+| anthropic/claude-haiku-4.5  | 100 t/s | Speed + Anthropic values      |
+| openai/gpt-5.2              | 95 t/s  | Speed + tools                 |
+| anthropic/claude-sonnet-4.5 | 60 t/s  | Balanced (default)            |
+| anthropic/claude-opus-4.5   | 40 t/s  | Deep work, quality over speed |
 
-Speed signals: "quick", "fast", "briefly", "just tell me", "real quick", "in a
-nutshell", short questions, simple lookups, casual conversation.
-
-Speed ranking (tokens per second):
-
-| Model                       | Speed   | Tier       |
-| --------------------------- | ------- | ---------- |
-| x-ai/grok-4.1-fast          | 151 t/s | Fast       |
-| google/gemini-3-pro-preview | 124 t/s | Fast       |
-| anthropic/claude-haiku-4.5  | 100 t/s | Fast       |
-| openai/gpt-5.2              | 95 t/s  | Moderate   |
-| perplexity/sonar-pro        | 80 t/s  | Moderate   |
-| anthropic/claude-sonnet-4.5 | 60 t/s  | Moderate   |
-| anthropic/claude-opus-4.5   | 40 t/s  | Deliberate |
-
-Speed-first decision flow:
-
-1. User signals speed → Route to fastest model that handles the task
-2. Simple question, no attachments → Haiku (100 t/s, Anthropic values)
-3. Simple question + audio/video → Gemini Pro (124 t/s, required for media)
-4. Need tools + speed → GPT-5.2 (95 t/s, best tool accuracy)
-5. Maximum speed, don't care about provider → Grok (151 t/s)
-
-When speed is priority, set reasoning to "none" or "minimal". Reasoning tokens add
-latency. A 100-token response at 100 t/s takes 1 second. The same response with 2K
-reasoning tokens takes 21 seconds.
-
-Speed tiers:
-
-- Fast (100+ t/s): Sub-second responses for short answers
-- Moderate (60-99 t/s): 1-2 seconds for typical responses
-- Deliberate (below 60 t/s): Quality over speed, use for complex work
+When speed priority: set reasoning to "none" or "minimal".
 
 ## Primary Models
 
-### anthropic/claude-sonnet-4.5
+**anthropic/claude-sonnet-4.5** — Default. 1M context, 60 t/s, $3/$15. Images, PDFs,
+reliable tools. Use for: most requests, code, conversation, creative, documents.
 
-Our default. Context: 1M tokens. Speed: 60 t/s (moderate). Cost: $3/$15 per million.
-Images, PDFs. Reliable tools. Token-budget reasoning (1K-32K tokens).
+**anthropic/claude-opus-4.5** — Frontier. 200K context, 40 t/s, $5/$25. Coding champion,
+math leader. Use for: complex coding, deep reasoning, difficult math, thorough analysis.
 
-Choose when: Most requests. Code, conversation, creative work, tool use, documents. The
-query doesn't clearly call for Opus depth or Haiku speed.
+**anthropic/claude-haiku-4.5** — Fast. 200K context, 100 t/s, $1/$5. Use for: simple
+facts, quick lookups, speed signals, budget-conscious.
 
-Temperature: 0.3-0.5 code/factual, 0.6-0.7 conversation, 0.7-0.9 creative.
+**openai/gpt-5.2** — Tools champion (98.7% accuracy). 400K context, 95 t/s, $1.75/$14.
+Use for: ANY tool calling, multi-step workflows, function calling.
 
-### anthropic/claude-opus-4.5
+**google/gemini-3-pro-preview** — Multimodal. 1M context, 124 t/s, $2/$12. Audio, video,
+creative leader. Use for: audio attached, video attached, creative writing.
 
-Frontier capability. Coding champion (WebDev Arena #1, ELO 1519). Math leader (Arena
-Math #1). Context: 200K tokens. Speed: 40 t/s (deliberate). Cost: $5/$25 per million.
-Images, PDFs. Token-budget reasoning.
-
-Choose when: Complex coding tasks. Software engineering. Deep multi-step reasoning.
-Difficult math/logic. User asks for thorough analysis. Nuanced emotional support. Query
-requires most capable model.
-
-Temperature: 0.3-0.5 code, 0.4-0.6 reasoning, 0.5-0.7 exploration.
-
-### anthropic/claude-haiku-4.5
-
-Speed champion for Anthropic at 100 t/s (fast tier). Fast and capable. Context: 200K
-tokens. Cost: $1/$5 per million. Images, PDFs. Token-budget reasoning.
-
-Choose when: Simple factual questions. Quick lookups. User signals speed ("quick",
-"briefly"). Budget-conscious. Straightforward queries.
-
-Temperature: 0.2-0.4 factual, 0.5 conversational.
-
-## Specialized Models
-
-### openai/gpt-5.2
-
-Tool-calling champion (98.7% accuracy - highest measured). Default for all tool use.
-Professional work leader (GDPval ELO 1474, 70.9% vs experts). Intelligence: 73 (tied
-#1). Context: 400K tokens. Speed: 95 t/s (moderate - fast for a frontier model). Cost:
-$1.75/$14 per million. Images, PDFs, files. Adaptive reasoning (xhigh level). Released
-Dec 11, 2025.
-
-Choose when: ANY tool calling. Multi-step agentic workflows. Function calling accuracy
-critical. Professional knowledge work. Research with tools. Software engineering
-(SWE-Bench 80%). Extended reasoning + tools.
-
-Temperature: 0.4-0.5 tools/code, 0.5-0.7 analysis.
-
-### google/gemini-3-pro-preview
-
-Arena champion (Overall #1, ELO 1492). Creative leader (Creative Writing #1). Full
-multimodal. Context: 1M tokens. Speed: 124 t/s (fast tier - excellent for quick
-multimodal). Cost: $2/$12 per million. Text, images, video, audio, PDF. No extended
-reasoning. Intelligence: 73 (tied #1).
-
-Choose when: Audio attached. Video attached. Mixed media. Creative writing. Balanced
-high-quality work. Multimodal needs Claude lacks.
-
-Temperature: 0.5-0.7 general, 0.7-0.9 creative.
-
-### x-ai/grok-4.1-fast
-
-Speed champion at 151 t/s (fastest in roster). Context champion (2M tokens - only model
-with >1M). Budget leader ($0.20/$0.50 per million). Intelligence: 64. Multimodal.
-Effort-based reasoning (high/medium/low/minimal/none).
-
-Choose when: Context exceeds 400K tokens (rare). Massive multi-document analysis. When
-context length is THE constraint. Extreme budget scenarios.
-
-For tool calling, use GPT 5.2 instead (98.7% vs Grok's 99% - functionally equivalent but
-GPT has better overall capability).
-
-Temperature: 0.4-0.6.
-
-## Reasoning
-
-Some models generate reasoning tokens before the response. Improves quality for complex
-tasks.
-
-High effort/large budget: Complex multi-step problems. Math/logic. Deep synthesis. Many
-variables or edge cases. User requests thorough thinking. Quality over speed/cost.
-
-Medium effort: Moderate complexity. Balanced quality/speed. Standard analysis. Default
-for reasoning-capable models on non-trivial queries.
-
-Low effort: Simpler questions. User signals speed. Cost sensitivity.
-
-No reasoning: Quick lookups, simple facts. Creative writing (reasoning reduces
-creativity). Casual conversation. Speed/cost priority.
-
-Cost example (Sonnet at $15/M output): 2K tokens = $0.03, 8K = $0.12, 32K = $0.48.
-
-Model behavior:
-
-- Anthropic: Token budget (1024-32000). Returns reasoning tokens.
-- Grok: Effort level (high/medium/low/minimal/none). Returns reasoning tokens.
-- OpenAI: Effort level. Reasons internally, doesn't expose tokens.
-- Gemini Pro: No extended reasoning.
-
-## Temperature
-
-0.0-0.3: Code, math, factual, precise 0.4-0.6: Conversation, analysis, explanations
-0.7-0.9: Creative, brainstorming, exploration 1.0: Maximum creativity (rare)
-
-Lower signals: code, debug, "exactly", "precisely", technical, math, facts Higher
-signals: "brainstorm", "creative", "ideas", "explore", storytelling, open-ended
+**x-ai/grok-4.1-fast** — Speed/context champion. 2M context, 151 t/s, $0.20/$0.50. Use
+for: context >400K, sensitive topics, maximum speed.
 
 ## Attachment Routing
 
-Audio: FORCE google/gemini-3-pro-preview (only native audio support) Video: FORCE
-google/gemini-3-pro-preview (only true video support) PDF: PREFER
-anthropic/claude-sonnet-4.5 (best document understanding) Images: PREFER
-anthropic/claude-sonnet-4.5 (excellent vision) Code files: PREFER
-anthropic/claude-sonnet-4.5 (superior comprehension, 1M context)
+- Audio: FORCE google/gemini-3-pro-preview (only native audio)
+- Video: FORCE google/gemini-3-pro-preview (only true video)
+- PDF: PREFER anthropic/claude-sonnet-4.5 (best document understanding)
+- Images: PREFER anthropic/claude-sonnet-4.5 (excellent vision)
+- Code files: PREFER anthropic/claude-sonnet-4.5 (1M context)
 
-FORCE means mandatory. PREFER means choose unless other constraints apply.
+FORCE = mandatory. PREFER = unless other constraints apply.
 
 ## Sensitivity Routing
 
-Grok engages directly with controversial topics where other models hedge or decline.
+Route to x-ai/grok-4.1-fast for: political opinions, edgy humor, controversial topics,
+"honest opinion", "unfiltered", "what do you really think". Temperature 0.6-0.8.
 
-Route to x-ai/grok-4.1-fast when query involves:
+## Reasoning
 
-- Political opinions, controversial figures, partisan topics
-- Edgy or dark humor
-- Controversial social/cultural discussions
-- Unfiltered or "raw" perspective requests
-- Historical or philosophical explorations of taboo subjects
+- High: complex multi-step, math/logic, deep synthesis
+- Medium: moderate complexity, standard analysis (default for non-trivial)
+- Low: simpler questions, speed signals
+- None: quick lookups, creative writing, casual chat
 
-User signals: "honest opinion", "unfiltered", "what do you really think", "raw take",
-seeking direct engagement over careful hedging.
+## Temperature
 
-Temperature: 0.6-0.8 (allow personality).
-
-Tradeoff: Grok has lower general intelligence (64 vs 73) but higher willingness to
-engage. For sensitive topics requiring deep analysis, weigh engagement vs capability.
-
-## Quick Reference
-
-| Model                       | Context | Speed   | Best For                 |
-| --------------------------- | ------- | ------- | ------------------------ |
-| x-ai/grok-4.1-fast          | 2M      | 151 t/s | Speed, massive context   |
-| google/gemini-3-pro-preview | 1M      | 124 t/s | Speed + multimodal       |
-| anthropic/claude-haiku-4.5  | 200K    | 100 t/s | Speed + Anthropic values |
-| openai/gpt-5.2              | 400K    | 95 t/s  | Tools, professional work |
-| anthropic/claude-sonnet-4.5 | 1M      | 60 t/s  | Default, balanced        |
-| anthropic/claude-opus-4.5   | 200K    | 40 t/s  | Deep work, quality       |
+- 0.0-0.3: code, math, factual
+- 0.4-0.6: conversation, analysis
+- 0.7-0.9: creative, brainstorming
+- 1.0: maximum creativity (rare)
 
 ## Fallback
 


### PR DESCRIPTION
## Summary

Split the model rubric into two files to reduce Concierge prompt token usage:

- **Slim rubric** (`model-rubric.md`): 85 lines, ~800 tokens — used for routing decisions
- **Detailed rubric** (`model-rubric-detailed.md`): 240 lines — full reference with research basis

The slim rubric is injected into every Concierge call. Removing research citations, detailed model profiles, speed-first decision flows, fallback chain documentation, and update history cuts tokens by ~60%.

### Token Reduction

| Metric | Original | Slim | Reduction |
|--------|----------|------|-----------|
| Lines | 214 | 85 | 60% |
| Words | ~1,300 | 442 | 66% |
| Est. tokens | ~2K | ~800 | 60% |

### Changes

1. **`knowledge/model-rubric.md`** — Slimmed down to essentials:
   - User hints (highest priority)
   - Speed routing table (compact)
   - Primary models (one line each)
   - Attachment routing rules
   - Brief sensitivity routing
   - Temperature/reasoning quick reference

2. **`knowledge/model-rubric-detailed.md`** — New file with everything else:
   - Research basis and source citations
   - Detailed model profiles with benchmarks
   - Speed-first decision flows
   - Fallback chain documentation
   - Update log with version history

3. **`.claude/commands/update-model-rubric.md`** — Updated to:
   - Generate both files
   - Explain why two files exist
   - Document token efficiency techniques
   - Reference prompt engineering rules

No code changes needed — the concierge already loads from `knowledge/model-rubric.md`.

## Test plan

- [x] All tests pass (1460/1460)
- [x] Build succeeds
- [x] Pre-push hooks pass
- [ ] Manual test: Verify routing still works correctly in Carmenta UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)