### PR TITLE
🐛 Fix: Manual title edits now persist correctly

### DIFF
--- a/lib/db/connections.ts
+++ b/lib/db/connections.ts
@@ -171,7 +171,9 @@ export async function getRecentConnections(
  */
 export async function updateConnection(
     connectionId: number,
-    updates: Partial<Pick<NewConnection, "title" | "status" | "modelId">>
+    updates: Partial<
+        Pick<NewConnection, "title" | "status" | "modelId" | "titleEdited">
+    >
 ): Promise<Connection | null> {
     // If title is being updated, regenerate the slug with encoded ID
     const updateData: Record<string, unknown> = {


### PR DESCRIPTION
## Summary
- Fixes bug where manually edited connection titles reverted to auto-generated titles
- The `updateConnection` function type excluded `titleEdited` from allowed updates, so the flag was silently dropped and never reached the database
- When title evolution ran, it saw `titleEdited: false` and overwrote the manual edit with an auto-generated title

## Changes
- Added `titleEdited` to the Pick type in `lib/db/connections.ts` line 174

## Test plan
- [x] Build passes
- [x] All 1460 tests pass
- [x] Code review confirms fix addresses root cause

Fixes #317

🤖 Generated with [Claude Code](https://claude.com/claude-code)