### PR TITLE
🐛 Fix stop triggering new connections instead of stopping

### DIFF
--- a/components/connection/connect-runtime-provider.tsx
+++ b/components/connection/connect-runtime-provider.tsx
@@ -475,6 +475,10 @@ function createFetchWrapper(
                         modelId: conciergeData?.modelId ?? null,
                     });
                     onNewConnectionCreated(decodedTitle, connectionSlug);
+
+                    // Update the ref so subsequent requests (regenerate, follow-up messages)
+                    // use this connection instead of creating new ones
+                    connectionIdRef.current = connectionId;
                 }
             }
 


### PR DESCRIPTION
## Summary
- **Root cause**: When creating a new connection from `/connection/new`, the `connectionIdRef` was never updated with the newly created connection's ID
- **Impact**: Subsequent requests (like regenerate or follow-up messages) would go out without a connectionId, triggering the API to create another new connection each time - giving the appearance that "stop triggers regeneration"
- **Fix**: Update `connectionIdRef.current` immediately when a new connection is created, ensuring subsequent requests use the correct connection

## Test plan
- [x] TypeScript compiles without errors
- [x] All 1460 unit/integration tests pass
- [x] Linting passes
- [ ] Manual test: Send message on /connection/new, click stop, then click regenerate - should stay on same connection

Fixes #315

🤖 Generated with [Claude Code](https://claude.com/claude-code)