### PR TITLE
🐛 Fix title editing not persisting (#317)

### DIFF
--- a/components/connection/connection-context.tsx
+++ b/components/connection/connection-context.tsx
@@ -359,7 +359,7 @@ export function ConnectionProvider({
             unstarredConnections,
             activeConnection,
             activeConnectionId,
-            displayTitle: activeConnection?.title ?? displayTitle,
+            displayTitle: displayTitle ?? activeConnection?.title ?? null,
             freshConnectionIds,
             runningCount,
             isStreaming,


### PR DESCRIPTION
## Summary

Fixes #317 - Manual title editing reverts immediately after saving.

**Root Cause**: The `displayTitle` in connection context was using wrong priority:
```typescript
displayTitle: activeConnection?.title ?? displayTitle,  // Bug: server wins
displayTitle: displayTitle ?? activeConnection?.title,  // Fix: user edit wins
```

When users edited a title:
1. Optimistic update set `displayTitle` to the new title
2. But context value used `activeConnection?.title` (stale server prop) first
3. The old title immediately overwrote the user's edit

**Fix**: Reversed the nullish coalescing order so `displayTitle` (user's optimistic edit) takes precedence over `activeConnection?.title` (stale server data).

## Testing

- ✅ Build passes
- ✅ All 1465 tests pass
- ✅ Lint passes
- ✅ Verified all title display scenarios work:
  - Navigation to existing connection shows server title
  - New connection shows generated title
  - Manual edit persists correctly
  - Error revert works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)