### PR TITLE
✨ Add comprehensive tooltips across interface

### DIFF
--- a/components/connection/connection-chooser.tsx
+++ b/components/connection/connection-chooser.tsx
@@ -204,7 +204,6 @@ function EditableTitle({
                 onClick={onOpenDropdown}
                 onDoubleClick={handleStartEdit}
                 className="btn-subtle-text flex items-center gap-2"
-                title="Click to open connections, double-click to edit title"
             >
                 <AnimatedTitle title={title} />
             </button>
@@ -790,8 +789,9 @@ export function ConnectionChooser({
                             {/* Search button */}
                             <button
                                 onClick={openDropdown}
-                                className="btn-subtle-icon text-foreground/40 hover:text-foreground/60"
+                                className="btn-subtle-icon tooltip text-foreground/40 hover:text-foreground/60"
                                 aria-label="Search connections"
+                                data-tooltip="Browse recent conversations"
                             >
                                 <Search className="h-4 w-4" />
                             </button>
@@ -842,13 +842,14 @@ export function ConnectionChooser({
                                 onClick={createNewConnection}
                                 disabled={isPending}
                                 className={cn(
-                                    "flex items-center justify-center",
+                                    "tooltip flex items-center justify-center",
                                     isMobilePlacement
                                         ? "h-10 w-10 flex-shrink-0 rounded-full bg-primary/15 text-primary transition-colors hover:bg-primary/25"
                                         : "btn-subtle-text gap-1.5 text-sm text-foreground/50 hover:text-foreground/80",
                                     "disabled:cursor-not-allowed disabled:opacity-50"
                                 )}
                                 aria-label="New connection"
+                                data-tooltip="Start fresh with a new conversation"
                             >
                                 {isPending ? (
                                     <Loader2 className="h-4 w-4 animate-spin" />
@@ -877,8 +878,9 @@ export function ConnectionChooser({
                         >
                             <button
                                 onClick={openDropdown}
-                                className="btn-subtle-icon text-foreground/40 hover:text-foreground/60"
+                                className="btn-subtle-icon tooltip text-foreground/40 hover:text-foreground/60"
                                 aria-label="Search connections"
+                                data-tooltip="Browse recent conversations"
                             >
                                 <Search className="h-4 w-4" />
                             </button>
@@ -897,8 +899,9 @@ export function ConnectionChooser({
                                 <button
                                     onClick={createNewConnection}
                                     disabled={isPending}
-                                    className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-50"
+                                    className="tooltip flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-full bg-primary/15 text-primary transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-50"
                                     aria-label="New connection"
+                                    data-tooltip="Start fresh with a new conversation"
                                 >
                                     {isPending ? (
                                         <Loader2 className="h-4 w-4 animate-spin" />

--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -1081,8 +1081,9 @@ function MessageActions({
                 <button
                     onClick={onEdit}
                     aria-label="Edit message"
+                    data-tooltip="Revise this and get a fresh response"
                     className={cn(
-                        "inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-all",
+                        "tooltip inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md transition-all",
                         "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                         "hover:bg-foreground/10 active:bg-foreground/15",
                         "text-foreground/60 hover:text-foreground/90"

--- a/components/connection/model-selector/model-selector-trigger.tsx
+++ b/components/connection/model-selector/model-selector-trigger.tsx
@@ -60,11 +60,12 @@ export function ModelSelectorTrigger({
                 onClick={() => setIsOpen(true)}
                 disabled={disabled}
                 className={cn(
-                    "btn-icon-glass group relative",
+                    "btn-icon-glass tooltip group relative",
                     hasOverrides && !isAuto ? "ring-2 ring-primary/40" : "",
                     disabled && "btn-disabled"
                 )}
                 aria-label="Model settings"
+                data-tooltip="Choose AI model and adjust how we respond"
             >
                 {displayModel ? (
                     <ProviderIcon

--- a/components/connection/star-button.tsx
+++ b/components/connection/star-button.tsx
@@ -70,7 +70,7 @@ export function StarButton({
                 onToggle();
             }}
             className={cn(
-                "relative z-10 rounded-md transition-all",
+                "tooltip relative z-10 rounded-md transition-all",
                 padding,
                 // Visibility: always show if starred, otherwise follow showOnHover
                 isStarred
@@ -87,7 +87,7 @@ export function StarButton({
                     : "focus-visible:ring-foreground/20",
                 className
             )}
-            title={label || (isStarred ? "Unstar connection" : "Star connection")}
+            data-tooltip={label || "Keep this connection at the top of your list"}
             aria-label={label || (isStarred ? "Unstar connection" : "Star connection")}
             aria-pressed={isStarred}
         >

--- a/components/connection/upload-progress.tsx
+++ b/components/connection/upload-progress.tsx
@@ -115,8 +115,9 @@ function UploadItem({
             <button
                 type="button"
                 onClick={() => onRemove(id)}
-                className="shrink-0 rounded-full p-1 text-foreground/40 transition-colors hover:bg-foreground/10 hover:text-foreground/80"
+                className="tooltip shrink-0 rounded-full p-1 text-foreground/40 transition-colors hover:bg-foreground/10 hover:text-foreground/80"
                 aria-label="Remove file"
+                data-tooltip="Remove this attachment"
             >
                 <X className="h-4 w-4" />
             </button>

--- a/components/ui/oracle.tsx
+++ b/components/ui/oracle.tsx
@@ -58,8 +58,11 @@ export function Oracle({
                 config.container,
                 // Breathing animation
                 state === "breathing" && "oracle-breathing",
+                // Tooltip
+                href && "tooltip",
                 className
             )}
+            data-tooltip={href ? "Return to Carmenta home" : undefined}
         >
             <Image
                 src="/logos/icon-transparent.png"

--- a/components/ui/regenerate-button.tsx
+++ b/components/ui/regenerate-button.tsx
@@ -83,8 +83,9 @@ export function RegenerateButton({
             onClick={handleClick}
             aria-label={ariaLabel}
             disabled={disabled || isRegenerating}
+            data-tooltip="Ask for a different take on this"
             className={cn(
-                "inline-flex h-7 shrink-0 items-center justify-center rounded-md transition-all",
+                "tooltip inline-flex h-7 shrink-0 items-center justify-center rounded-md transition-all",
                 "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
                 "hover:bg-foreground/10 active:bg-foreground/15",
                 disabled || isRegenerating

--- a/components/ui/user-auth-button.tsx
+++ b/components/ui/user-auth-button.tsx
@@ -132,8 +132,9 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
             {/* Trigger button - UserCircle icon */}
             <button
                 onClick={() => setIsOpen(!isOpen)}
-                className="btn-icon-glass group relative"
+                className="btn-icon-glass tooltip group relative"
                 aria-label="User menu"
+                data-tooltip="Your account, integrations, and appearance"
             >
                 <UserCircle2 className="h-6 w-6 text-foreground/50 transition-colors group-hover:text-foreground/80 sm:h-7 sm:w-7 md:h-8 md:w-8" />
             </button>
@@ -256,12 +257,14 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                                                     )
                                                                 }
                                                                 className={cn(
-                                                                    "flex items-center justify-center rounded-md px-2 py-1 transition-all",
+                                                                    "tooltip flex items-center justify-center rounded-md px-2 py-1 transition-all",
                                                                     isSelected
                                                                         ? "bg-background text-foreground shadow-sm"
                                                                         : "text-foreground/40 hover:text-foreground/70"
                                                                 )}
-                                                                title={option.label}
+                                                                data-tooltip={
+                                                                    option.label
+                                                                }
                                                             >
                                                                 <Icon className="h-3.5 w-3.5" />
                                                             </button>
@@ -303,7 +306,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                                                 );
                                                             }}
                                                             className={cn(
-                                                                "h-10 w-10 rounded-full transition-all",
+                                                                "tooltip h-10 w-10 rounded-full transition-all",
                                                                 isCommitted
                                                                     ? "ring-2 ring-foreground/60 ring-offset-2 ring-offset-background"
                                                                     : "opacity-60 hover:scale-110 hover:opacity-100"
@@ -312,7 +315,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                                                 backgroundColor:
                                                                     variant.color,
                                                             }}
-                                                            title={variant.label}
+                                                            data-tooltip={variant.label}
                                                         />
                                                     );
                                                 })}


### PR DESCRIPTION
## Summary

- **Oracle logo**: "Return to Carmenta home" - explains what clicking does
- **Search connections**: "Browse recent conversations" - helpful context, not just "search"
- **New connection**: "Start fresh with a new conversation" - explains the action
- **User avatar**: "Your account, integrations, and appearance" - lists what's inside
- **Model selector**: "Choose AI model and adjust how we respond" - explains capabilities
- **Star button**: "Keep this connection at the top of your list" - explains benefit, not mechanic
- **Edit message**: "Revise this and get a fresh response" - explains the full flow
- **Regenerate**: "Ask for a different take on this" - warm, clear
- **Remove file**: "Remove this attachment" - straightforward
- **Theme toggles**: Converted from `title` to `data-tooltip` for consistency
- **Connection title**: Removed overly instructional tooltip (pencil icon teaches the interaction)

All tooltips use the CSS-only `data-tooltip` pattern per project standards (zero JS, zero dependencies).

## Design Decisions

- **Helpful over labeling**: Tooltips explain *why* you'd use something, not just what it is
- **Carmenta voice**: Warm but substantive, using "we" language where natural
- **Consistent pattern**: All use `tooltip` class + `data-tooltip` attribute
- **Removed unnecessary tooltips**: Connection title's "click to open, double-click to edit" was too instructional - the pencil icon teaches this naturally

## Test Plan

- [x] Build passes
- [x] All 1465 tests pass
- [x] Type checking passes
- [ ] Visual verification of tooltips in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)