### PR TITLE
⬆️ Upgrade AI SDK from 5.x to 6.0

### DIFF
--- a/__tests__/unit/app/api/connection/route.test.ts
+++ b/__tests__/unit/app/api/connection/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { MockLanguageModelV2, simulateReadableStream } from "ai/test";
+import { MockLanguageModelV3, simulateReadableStream } from "ai/test";
 import { encodeConnectionId } from "@/lib/sqids";
 
 // Mock Clerk currentUser
@@ -9,8 +9,8 @@ vi.mock("@clerk/nextjs/server", () => ({
 
 // Mock the OpenRouter provider to use a mock model
 vi.mock("@openrouter/ai-sdk-provider", async () => {
-    const { MockLanguageModelV2, simulateReadableStream } = await import("ai/test");
-    const mockModel = new MockLanguageModelV2({
+    const { MockLanguageModelV3, simulateReadableStream } = await import("ai/test");
+    const mockModel = new MockLanguageModelV3({
         doStream: async () => ({
             stream: simulateReadableStream({
                 chunks: [
@@ -21,8 +21,20 @@ vi.mock("@openrouter/ai-sdk-provider", async () => {
                     { type: "text-end", id: "text-1" },
                     {
                         type: "finish",
-                        finishReason: "stop",
-                        usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+                        finishReason: { unified: "stop", raw: undefined },
+                        usage: {
+                            inputTokens: {
+                                total: 10,
+                                noCache: undefined,
+                                cacheRead: undefined,
+                                cacheWrite: undefined,
+                            },
+                            outputTokens: {
+                                total: 5,
+                                text: undefined,
+                                reasoning: undefined,
+                            },
+                        },
                     },
                 ],
             }),

--- a/app/api/connection/route.ts
+++ b/app/api/connection/route.ts
@@ -648,7 +648,7 @@ export async function POST(req: Request) {
             // System messages are in the messages array with providerOptions for caching
             messages: [
                 ...systemMessages,
-                ...convertToModelMessages(messagesWithoutReasoning),
+                ...(await convertToModelMessages(messagesWithoutReasoning)),
             ],
             // Only pass tools if the model supports tool calling (e.g., Perplexity does not)
             // allTools includes both built-in tools and integration tools for connected services

--- a/evals/scorers/title-quality-scorer.ts
+++ b/evals/scorers/title-quality-scorer.ts
@@ -9,7 +9,7 @@
  */
 
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { generateObject } from "ai";
+import { generateText, Output } from "ai";
 import { z } from "zod";
 
 import type { ConciergeTestInput } from "../concierge-test-data";
@@ -134,9 +134,9 @@ export async function TitleQualityScorer({
     try {
         const openrouter = createOpenRouter({ apiKey });
 
-        const result = await generateObject({
+        const { output: scores } = await generateText({
             model: openrouter.chat(JUDGE_MODEL),
-            schema: titleQualitySchema,
+            output: Output.object({ schema: titleQualitySchema }),
             prompt: `You are evaluating the quality of a title generated for a conversation.
 
 <user-query>
@@ -164,8 +164,6 @@ Rate this title on each dimension from 0.0 to 1.0. Consider:
 Be honest and critical. Most titles should score between 0.5 and 0.9. Reserve 1.0 for truly excellent titles.`,
             temperature: 0.1,
         });
-
-        const scores = result.object;
 
         return [
             {

--- a/lib/ingestion/extraction/evaluate.ts
+++ b/lib/ingestion/extraction/evaluate.ts
@@ -8,7 +8,7 @@
  * - Authority: Is this source authoritative?
  */
 
-import { generateObject, type LanguageModel } from "ai";
+import { generateText, Output, type LanguageModel } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import * as Sentry from "@sentry/nextjs";
 
@@ -73,16 +73,16 @@ export async function evaluateForIngestion(
                     rawContent.sourceType
                 );
 
-                const { object } = await generateObject({
+                const { output } = await generateText({
                     model: getSonnet(),
+                    output: Output.object({ schema: ingestionResultSchema }),
                     prompt,
-                    schema: ingestionResultSchema,
                 });
 
                 const duration = Date.now() - startTime;
 
                 // Enrich items with source metadata
-                const enrichedItems = object.items.map((item) => ({
+                const enrichedItems = output.items.map((item) => ({
                     ...item,
                     sourceType: rawContent.sourceType,
                     sourceId: rawContent.sourceId,
@@ -90,7 +90,7 @@ export async function evaluateForIngestion(
                 }));
 
                 const result: IngestionResult = {
-                    ...object,
+                    ...output,
                     items: enrichedItems,
                 };
 

--- a/lib/ingestion/extraction/pre-extract.ts
+++ b/lib/ingestion/extraction/pre-extract.ts
@@ -3,7 +3,7 @@
  * Uses smallest/fastest model (Haiku) to identify what to search for
  */
 
-import { generateObject, type LanguageModel } from "ai";
+import { generateText, Output, type LanguageModel } from "ai";
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { assertEnv, env } from "@/lib/env";
 import { logger } from "@/lib/logger";
@@ -37,8 +37,9 @@ export async function preExtract(content: string): Promise<PreExtractionResult> 
     }
 
     try {
-        const { object } = await generateObject({
+        const { output } = await generateText({
             model: getHaiku(),
+            output: Output.object({ schema: preExtractionSchema }),
             prompt: `List entities and topics mentioned in this content for knowledge base search:
 
 ${content.slice(0, 2000)}
@@ -47,15 +48,14 @@ Extract:
 - People: Proper names of individuals (not roles like "the user" or "someone")
 - Projects: Names of projects, products, or systems
 - Topics: Technical concepts, technologies, or important subjects mentioned`,
-            schema: preExtractionSchema,
         });
 
         logger.debug(
-            { people: object.people, projects: object.projects, topics: object.topics },
+            { people: output.people, projects: output.projects, topics: output.topics },
             "Pre-extraction completed"
         );
 
-        return object;
+        return output;
     } catch (error) {
         logger.error({ error }, "Pre-extraction failed");
         // Return empty arrays rather than failing - we can still try ingestion

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@47ng/simple-e2ee": "^1.1.0",
-    "@ai-sdk/react": "^2.0.117",
+    "@ai-sdk/react": "^3.0.0",
     "@clerk/nextjs": "^6.36.3",
     "@marker.io/browser": "^0.20.2",
     "@openrouter/ai-sdk-provider": "^1.5.4",
@@ -60,7 +60,7 @@
     "@sentry/nextjs": "^10.32.0",
     "@supabase/supabase-js": "^2.89.0",
     "@t3-oss/env-nextjs": "^0.13.10",
-    "ai": "^5.0.115",
+    "ai": "^6.0.0",
     "autoevals": "^0.0.131",
     "braintrust": "^1.0.3",
     "browser-image-compression": "^2.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       '@ai-sdk/react':
-        specifier: ^2.0.117
-        version: 2.0.117(react@19.2.3)(zod@4.2.1)
+        specifier: ^3.0.0
+        version: 3.0.3(react@19.2.3)(zod@4.2.1)
       '@clerk/nextjs':
         specifier: ^6.36.3
         version: 6.36.3(next@16.1.0(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -22,7 +22,7 @@ importers:
         version: 0.20.2
       '@openrouter/ai-sdk-provider':
         specifier: ^1.5.4
-        version: 1.5.4(ai@5.0.115(zod@4.2.1))(zod@4.2.1)
+        version: 1.5.4(ai@6.0.3(zod@4.2.1))(zod@4.2.1)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -60,8 +60,8 @@ importers:
         specifier: ^0.13.10
         version: 0.13.10(typescript@5.9.3)(zod@4.2.1)
       ai:
-        specifier: ^5.0.115
-        version: 5.0.115(zod@4.2.1)
+        specifier: ^6.0.0
+        version: 6.0.3(zod@4.2.1)
       autoevals:
         specifier: ^0.0.131
         version: 0.0.131(ws@8.18.3)
@@ -277,14 +277,14 @@ packages:
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
-  '@ai-sdk/gateway@2.0.22':
-    resolution: {integrity: sha512-6fHjDfCbjfj4vyMExuLei7ir2///E5sNwNZaobdJsJIxJjDSsjzSLGO/aUI7p9eOnB8XctDrDSF5ilwDGpi6eg==}
+  '@ai-sdk/gateway@3.0.2':
+    resolution: {integrity: sha512-giJEg9ob45htbu3iautK+2kvplY2JnTj7ir4wZzYSQWvqGatWfBBfDuNCU5wSJt9BCGjymM5ZS9ziD42JGCZBw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/provider-utils@3.0.19':
-    resolution: {integrity: sha512-W41Wc9/jbUVXVwCN/7bWa4IKe8MtxO3EyA0Hfhx6grnmiYlCvpI8neSYWFE0zScXJkgA/YK3BRybzgyiXuu6JA==}
+  '@ai-sdk/provider-utils@4.0.1':
+    resolution: {integrity: sha512-de2v8gH9zj47tRI38oSxhQIewmNc+OZjYIOOaMoVWKL65ERSav2PYYZHPSPCrfOeLMkv+Dyh8Y0QGwkO29wMWQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -293,19 +293,15 @@ packages:
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/provider@2.0.0':
-    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+  '@ai-sdk/provider@3.0.0':
+    resolution: {integrity: sha512-m9ka3ptkPQbaHHZHqDXDF9C9B5/Mav0KTdky1k2HZ3/nrW2t1AgObxIVPyGDWQNS9FXT/FS6PIoSjpcP/No8rQ==}
     engines: {node: '>=18'}
 
-  '@ai-sdk/react@2.0.117':
-    resolution: {integrity: sha512-qfwz4p1ev+i/M9rsOUEe53UgzxMUz7e4wrImWdkuFrpD78MBIj53eE/LtyCeAYSCFVSz3JfIDvtdk5MjTrNcbA==}
+  '@ai-sdk/react@3.0.3':
+    resolution: {integrity: sha512-mLIgQuBdIX9gxCYQN3Pv/J8ARoFreIKYr/TVQtI+FwEzejuGFimTyhDln7UIBfrnm3Mpn1xENIWZfDfCRF7wkw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
-      zod: ^3.25.76 || ^4.1.8
-    peerDependenciesMeta:
-      zod:
-        optional: true
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2885,8 +2881,8 @@ packages:
     resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
     engines: {node: '>= 8.0.0'}
 
-  ai@5.0.115:
-    resolution: {integrity: sha512-aVuHx0orGxXvhyL7oXUyW8TnWQE6Al8f3Bl6VZjz0WHMV+WaACHPkSyvQ3wje2QCUGzdl5DBF5d+OaXyghPQyg==}
+  ai@6.0.3:
+    resolution: {integrity: sha512-OOo+/C+sEyscoLnbY3w42vjQDICioVNyS+F+ogwq6O5RJL/vgWGuiLzFwuP7oHTeni/MkmX8tIge48GTdaV7QQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -6704,16 +6700,16 @@ snapshots:
 
   '@adobe/css-tools@4.4.4': {}
 
-  '@ai-sdk/gateway@2.0.22(zod@4.2.1)':
+  '@ai-sdk/gateway@3.0.2(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.2.1)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.2.1)
       '@vercel/oidc': 3.0.5
       zod: 4.2.1
 
-  '@ai-sdk/provider-utils@3.0.19(zod@4.2.1)':
+  '@ai-sdk/provider-utils@4.0.1(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
       zod: 4.2.1
@@ -6722,19 +6718,19 @@ snapshots:
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/provider@2.0.0':
+  '@ai-sdk/provider@3.0.0':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@2.0.117(react@19.2.3)(zod@4.2.1)':
+  '@ai-sdk/react@3.0.3(react@19.2.3)(zod@4.2.1)':
     dependencies:
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.2.1)
-      ai: 5.0.115(zod@4.2.1)
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.2.1)
+      ai: 6.0.3(zod@4.2.1)
       react: 19.2.3
       swr: 2.3.8(react@19.2.3)
       throttleit: 2.1.0
-    optionalDependencies:
-      zod: 4.2.1
+    transitivePeerDependencies:
+      - zod
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -7569,10 +7565,10 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@openrouter/ai-sdk-provider@1.5.4(ai@5.0.115(zod@4.2.1))(zod@4.2.1)':
+  '@openrouter/ai-sdk-provider@1.5.4(ai@6.0.3(zod@4.2.1))(zod@4.2.1)':
     dependencies:
       '@openrouter/sdk': 0.1.27
-      ai: 5.0.115(zod@4.2.1)
+      ai: 6.0.3(zod@4.2.1)
       zod: 4.2.1
 
   '@openrouter/sdk@0.1.27':
@@ -9243,11 +9239,11 @@ snapshots:
     dependencies:
       humanize-ms: 1.2.1
 
-  ai@5.0.115(zod@4.2.1):
+  ai@6.0.3(zod@4.2.1):
     dependencies:
-      '@ai-sdk/gateway': 2.0.22(zod@4.2.1)
-      '@ai-sdk/provider': 2.0.0
-      '@ai-sdk/provider-utils': 3.0.19(zod@4.2.1)
+      '@ai-sdk/gateway': 3.0.2(zod@4.2.1)
+      '@ai-sdk/provider': 3.0.0
+      '@ai-sdk/provider-utils': 4.0.1(zod@4.2.1)
       '@opentelemetry/api': 1.9.0
       zod: 4.2.1
 


### PR DESCRIPTION
## Summary

Upgrades Vercel AI SDK from 5.0.115 to 6.0.0.

- **`convertToModelMessages` is now async** - Added `await` where needed
- **`generateObject` deprecated** - Migrated to `generateText` + `Output.object()` pattern
- **Test mocks updated** - `MockLanguageModelV3` has new usage structure with detailed token breakdown

### Files Changed

| File | Change |
|------|--------|
| `package.json` | Version bumps |
| `app/api/connection/route.ts` | Add await to convertToModelMessages |
| `evals/scorers/title-quality-scorer.ts` | Migrate to Output.object() |
| `lib/ingestion/extraction/pre-extract.ts` | Migrate to Output.object() |
| `lib/ingestion/extraction/evaluate.ts` | Migrate to Output.object() |
| `__tests__/unit/app/api/connection/route.test.ts` | Update mock structure |
| `knowledge/components/vercel-ai-sdk.md` | Update docs for v6 |

### End User Impact

This is a foundation upgrade. Users won't see immediate changes, but this enables:
- Future tool approval UI for destructive operations (#339)
- Foundation for AI Elements components (#336)
- Transient streaming for better UX (#337)
- DevTools for debugging (#338)

### Deferred Features

Tracked in separate issues:
- #336 AI Elements
- #337 Transient Streaming  
- #338 DevTools

## Test plan

- [x] Type-check passes
- [x] All 1465 tests pass
- [x] Pre-push validation passes
- [ ] Manual smoke test of chat streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)