### PR TITLE
🎄 Add Christmas theme with color swatches in selector

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -435,6 +435,87 @@
         --glass-surface: rgba(16, 18, 20, 0.97);
         --glass-shadow: 0 4px 24px rgba(0, 0, 0, 0.5);
     }
+
+    /* ===== CHRISTMAS THEME ===== */
+    /* Festive warmth - deep reds, forest greens, warm golds */
+    :root[data-theme="christmas"] {
+        --background: 45 30% 96%; /* Warm cream like fresh snow */
+        --foreground: 350 35% 22%; /* Deep cranberry for text */
+
+        --card: 0 0% 100%;
+        --card-foreground: 350 35% 22%;
+
+        --popover: 0 0% 100%;
+        --popover-foreground: 350 35% 22%;
+
+        --primary: 350 65% 45%; /* Deep holly red */
+        --primary-foreground: 0 0% 100%;
+
+        --secondary: 140 40% 88%; /* Soft pine needle */
+        --secondary-foreground: 350 35% 22%;
+
+        --muted: 45 20% 90%;
+        --muted-foreground: 350 20% 42%;
+
+        --accent: 42 85% 55%; /* Warm gold like candlelight */
+        --accent-foreground: 350 35% 22%;
+
+        --destructive: 0 60% 70%;
+        --destructive-foreground: 0 0% 100%;
+
+        --border: 45 20% 82%;
+        --input: 45 20% 88%;
+        --ring: 350 65% 45%;
+
+        /* Glassmorphism - warm holiday tinted */
+        --glass-bg: rgba(180, 80, 80, 0.12);
+        --glass-bg-hover: rgba(180, 80, 80, 0.2);
+        --glass-bg-active: rgba(180, 80, 80, 0.28);
+        --glass-surface: rgba(255, 252, 245, 0.92);
+        --glass-shadow: 0 4px 16px rgba(140, 60, 60, 0.12);
+    }
+
+    :root[data-theme="christmas"].dark {
+        /* Fireside warmth - cozy ember glow, not cold winter */
+        --background: 350 40% 7%; /* Deep cranberry-tinged black */
+        --foreground: 45 25% 92%; /* Warm cream like candlelight */
+
+        /* Cards glow like wrapped presents by firelight */
+        --card: 350 35% 12%;
+        --card-foreground: 45 25% 92%;
+
+        --popover: 350 38% 9%;
+        --popover-foreground: 45 25% 92%;
+
+        /* Primary - Luminous holly berry */
+        --primary: 350 70% 58%;
+        --primary-foreground: 350 40% 7%;
+
+        /* Secondary - Deep evergreen shadow */
+        --secondary: 145 35% 18%;
+        --secondary-foreground: 45 25% 92%;
+
+        --muted: 350 28% 15%;
+        --muted-foreground: 45 18% 62%;
+
+        /* Accent - Glowing golden ornament */
+        --accent: 42 80% 58%;
+        --accent-foreground: 350 40% 7%;
+
+        --destructive: 0 50% 50%;
+        --destructive-foreground: 0 0% 100%;
+
+        --border: 350 24% 24%;
+        --input: 350 26% 17%;
+        --ring: 350 70% 58%;
+
+        /* Fireside glassmorphism - warm and inviting */
+        --glass-bg: rgba(160, 70, 70, 0.18);
+        --glass-bg-hover: rgba(180, 85, 85, 0.28);
+        --glass-bg-active: rgba(200, 100, 100, 0.35);
+        --glass-surface: rgba(32, 18, 18, 0.96);
+        --glass-shadow: 0 4px 24px rgba(120, 50, 50, 0.3);
+    }
 }
 
 @layer base {

--- a/components/ui/holographic-background.tsx
+++ b/components/ui/holographic-background.tsx
@@ -160,6 +160,29 @@ const THEME_PALETTES: Record<
         ],
         darkBg: "#0A0B0D", // Pure void with cyan whisper
     },
+    christmas: {
+        light: [
+            { r: 230, g: 180, b: 180 }, // Rose Blush
+            { r: 200, g: 220, b: 200 }, // Pine Frost
+            { r: 255, g: 240, b: 200 }, // Candlelight Gold
+            { r: 220, g: 200, b: 190 }, // Warm Cream
+            { r: 240, g: 190, b: 190 }, // Soft Holly
+            { r: 210, g: 230, b: 210 }, // Mistletoe
+            { r: 255, g: 235, b: 210 }, // Warm Glow
+            { r: 225, g: 210, b: 200 }, // Eggnog
+        ],
+        dark: [
+            { r: 160, g: 70, b: 80 }, // Holly Berry
+            { r: 180, g: 90, b: 95 }, // Cranberry Glow
+            { r: 80, g: 120, b: 90 }, // Evergreen Shadow
+            { r: 200, g: 150, b: 90 }, // Golden Ornament
+            { r: 150, g: 65, b: 75 }, // Deep Garnet
+            { r: 170, g: 85, b: 90 }, // Mulled Wine
+            { r: 90, g: 130, b: 95 }, // Forest Pine
+            { r: 190, g: 140, b: 85 }, // Amber Glow
+        ],
+        darkBg: "#120808", // Deep fireside warmth
+    },
 };
 
 const BLOB_COUNT = 8; // Reduced from 12 for performance
@@ -214,6 +237,16 @@ const WARM_PRESENCE_COLORS: Record<
         dark: {
             inner: "rgba(140, 145, 160, 0.25)",
             outer: "rgba(120, 125, 140, 0.12)",
+        },
+    },
+    christmas: {
+        light: {
+            inner: "rgba(220, 160, 160, 0.4)",
+            outer: "rgba(255, 220, 180, 0.25)",
+        },
+        dark: {
+            inner: "rgba(180, 90, 95, 0.28)",
+            outer: "rgba(200, 150, 90, 0.15)",
         },
     },
 };

--- a/components/ui/theme-variant-selector.tsx
+++ b/components/ui/theme-variant-selector.tsx
@@ -5,27 +5,49 @@ import { useThemeVariant, type ThemeVariant } from "@/lib/theme/theme-context";
 import { cn } from "@/lib/utils";
 import * as Popover from "@radix-ui/react-popover";
 
-const THEMES: Array<{ value: ThemeVariant; label: string; description: string }> = [
-    { value: "carmenta", label: "Carmenta", description: "Royal purple elegance" },
+interface ThemeConfig {
+    value: ThemeVariant;
+    label: string;
+    description: string;
+    colors: [string, string, string]; // [primary, secondary, accent]
+}
+
+const THEMES: ThemeConfig[] = [
+    {
+        value: "carmenta",
+        label: "Carmenta",
+        description: "Royal purple elegance",
+        colors: ["hsl(270 40% 56%)", "hsl(280 20% 95%)", "hsl(280 30% 88%)"],
+    },
     {
         value: "warm-earth",
         label: "Warm Earth",
         description: "Terracotta, sage & gold",
+        colors: ["hsl(15 60% 60%)", "hsl(80 30% 85%)", "hsl(40 50% 65%)"],
     },
     {
         value: "arctic-clarity",
         label: "Arctic Clarity",
         description: "Ice blue precision",
+        colors: ["hsl(200 70% 55%)", "hsl(200 25% 90%)", "hsl(190 60% 65%)"],
     },
     {
         value: "forest-wisdom",
         label: "Forest Wisdom",
         description: "Natural green & amber",
+        colors: ["hsl(140 45% 45%)", "hsl(80 25% 88%)", "hsl(35 60% 60%)"],
     },
     {
         value: "monochrome",
         label: "Monochrome",
-        description: "Minimal, precise, professional",
+        description: "Minimal & precise",
+        colors: ["hsl(0 0% 35%)", "hsl(0 0% 88%)", "hsl(190 100% 50%)"],
+    },
+    {
+        value: "christmas",
+        label: "Christmas",
+        description: "Festive warmth",
+        colors: ["hsl(350 65% 45%)", "hsl(140 40% 88%)", "hsl(42 85% 55%)"],
     },
 ];
 
@@ -58,7 +80,7 @@ export function ThemeVariantSelector() {
                                 key={theme.value}
                                 onClick={() => setThemeVariant(theme.value)}
                                 className={cn(
-                                    "flex w-full items-start gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
+                                    "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
                                     themeVariant === theme.value
                                         ? "bg-primary/10 text-primary"
                                         : "text-foreground/80 hover:bg-foreground/5 hover:text-foreground/90"
@@ -74,6 +96,15 @@ export function ThemeVariantSelector() {
                                     <div className="text-xs opacity-70">
                                         {theme.description}
                                     </div>
+                                </div>
+                                <div className="flex shrink-0 gap-0.5">
+                                    {theme.colors.map((color, i) => (
+                                        <div
+                                            key={i}
+                                            className="h-4 w-4 rounded-full border border-foreground/10"
+                                            style={{ backgroundColor: color }}
+                                        />
+                                    ))}
                                 </div>
                             </button>
                         ))}

--- a/lib/theme/theme-context.tsx
+++ b/lib/theme/theme-context.tsx
@@ -10,13 +10,14 @@ import {
     type ReactNode,
 } from "react";
 
-// Theme variant types (5 launch themes)
+// Theme variant types
 export type ThemeVariant =
     | "carmenta"
     | "warm-earth"
     | "arctic-clarity"
     | "forest-wisdom"
-    | "monochrome";
+    | "monochrome"
+    | "christmas";
 
 const STORAGE_KEY = "carmenta-theme-variant";
 const DEFAULT_THEME: ThemeVariant = "carmenta";


### PR DESCRIPTION
## Summary

- **Christmas theme**: Festive holiday theme with deep holly reds, forest greens, and warm golds
  - Light mode: Warm cream backgrounds, soft pine accents
  - Dark mode: Cozy fireside warmth (think crackling fireplace, not cold winter)
  - Full glassmorphism support with holiday-tinted effects
  - Holographic background with matching festive palette
  
- **Theme color swatches**: All themes now show 3-color preview swatches in the selector for visual comparison before switching

## Design Decisions

- **Warm over cold**: Dark mode uses cranberry-tinged backgrounds with ember glow rather than icy blues. The goal is "by the fireplace" not "out in the snow"
- **Color palette**: Primary (holly red), secondary (evergreen), accent (candlelight gold) - a classic holiday trio that remains readable and professional
- **Additive approach**: The Christmas theme follows exact patterns of existing themes - no architectural changes, just new CSS variables and type extension

## Testing

- Type checking passes
- All 1455 tests pass
- Lint passes (pre-existing warnings unrelated to this change)
- Theme selector renders correctly with new swatches
- Both light and dark variants tested visually

Fixes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)