### PR TITLE
📳 Haptic Feedback (Mobile)

### DIFF
--- a/components/connection/connect-runtime-provider.tsx
+++ b/components/connection/connect-runtime-provider.tsx
@@ -28,6 +28,7 @@ import { AlertCircle, RefreshCw, X } from "lucide-react";
 
 import { logger } from "@/lib/client-logger";
 import { cn } from "@/lib/utils";
+import { triggerHaptic } from "@/lib/hooks/use-haptic-feedback";
 import {
     ConciergeProvider,
     useConcierge,
@@ -340,6 +341,11 @@ function RuntimeErrorBanner({
     onRetry: () => void;
 }) {
     const displayMessage = parseErrorMessage(error.message);
+
+    // Trigger haptic on mount (error appeared)
+    useEffect(() => {
+        triggerHaptic("error");
+    }, []);
 
     return (
         <div

--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -34,6 +34,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { useIsMobile } from "@/lib/hooks/use-mobile";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 import type { UIMessage } from "@ai-sdk/react";
 
 import * as Sentry from "@sentry/nextjs";
@@ -1724,6 +1725,7 @@ function Composer({ isNewConversation, onMarkMessageStopped }: ComposerProps) {
     const inputRef = useRef<HTMLTextAreaElement>(null);
     const formRef = useRef<HTMLFormElement>(null);
     const isMobile = useIsMobile();
+    const { triggerHaptic } = useHapticFeedback();
 
     // Show connection chooser on mobile when user has connections
     // Guard against undefined during SSR/hydration to prevent layout flash
@@ -1938,6 +1940,9 @@ function Composer({ isNewConversation, onMarkMessageStopped }: ComposerProps) {
             // Signal user engagement (dismisses feature tips whisper)
             emitUserEngaged();
 
+            // Haptic feedback on send
+            triggerHaptic("medium");
+
             const message = input.trim();
             lastSentMessageRef.current = message;
             wasStoppedRef.current = false; // Reset stop flag for new message
@@ -1979,11 +1984,13 @@ function Composer({ isNewConversation, onMarkMessageStopped }: ComposerProps) {
             append,
             clearFiles,
             emitUserEngaged,
+            triggerHaptic,
         ]
     );
 
     const handleStop = useCallback(() => {
         if (!isLoading) return;
+        triggerHaptic("light"); // Haptic feedback on stop
         wasStoppedRef.current = true; // Mark as user-stopped (no success checkmark)
         stop();
         // Clear concierge state immediately for clean UI reset
@@ -2004,6 +2011,7 @@ function Composer({ isNewConversation, onMarkMessageStopped }: ComposerProps) {
         lastSentMessageRef.current = null;
     }, [
         isLoading,
+        triggerHaptic,
         stop,
         setConcierge,
         messages,

--- a/components/connection/model-selector/model-selector-modal.tsx
+++ b/components/connection/model-selector/model-selector-modal.tsx
@@ -27,6 +27,7 @@ import {
 import { ProviderIcon } from "@/components/icons/provider-icons";
 import { cn } from "@/lib/utils";
 import { SteppedSlider } from "./stepped-slider";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 
 import type { ModelOverrides, ReasoningOverride } from "./types";
 
@@ -108,6 +109,7 @@ export function ModelSelectorModal({
     conciergeModel,
 }: ModelSelectorModalProps) {
     const modalRef = useRef<HTMLDivElement>(null);
+    const { triggerHaptic } = useHapticFeedback();
 
     // Handle Escape key to close modal
     useEffect(() => {
@@ -155,6 +157,7 @@ export function ModelSelectorModal({
             : 0; // Default to "Quick" (index 0)
 
     const handleModelSelect = (modelId: string | null) => {
+        triggerHaptic("medium"); // Haptic feedback on model selection
         onChange({ ...overrides, modelId });
     };
 

--- a/components/connection/model-selector/stepped-slider.tsx
+++ b/components/connection/model-selector/stepped-slider.tsx
@@ -8,9 +8,11 @@
  * - 5 preset levels with emoji indicators
  * - Two modes: position (no fill) vs progress (fill builds up)
  * - Compact design suitable for popovers
+ * - Haptic feedback on selection changes
  */
 
 import { cn } from "@/lib/utils";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 
 interface SteppedSliderProps {
     /** Current selected index */
@@ -42,6 +44,14 @@ export function SteppedSlider({
     progressMode = false,
 }: SteppedSliderProps) {
     const isPrimary = theme === "primary";
+    const { triggerHaptic } = useHapticFeedback();
+
+    const handleChange = (index: number) => {
+        if (index !== value) {
+            triggerHaptic("selection"); // Tactile feedback on slider change
+            onChange(index);
+        }
+    };
 
     return (
         <div>
@@ -73,7 +83,7 @@ export function SteppedSlider({
                     return (
                         <div key={i} className="flex flex-1 items-center">
                             <button
-                                onClick={() => onChange(i)}
+                                onClick={() => handleChange(i)}
                                 disabled={disabled}
                                 className="group flex flex-col items-center"
                             >

--- a/components/connection/star-button.tsx
+++ b/components/connection/star-button.tsx
@@ -12,6 +12,7 @@
 import { Star } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 
 interface StarButtonProps {
     isStarred: boolean;
@@ -36,6 +37,7 @@ export function StarButton({
 }: StarButtonProps) {
     const iconSize = size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4";
     const padding = size === "sm" ? "p-1.5" : "p-2";
+    const { triggerHaptic } = useHapticFeedback();
 
     // Track sparkle animation state
     const [showSparkle, setShowSparkle] = useState(false);
@@ -66,6 +68,9 @@ export function StarButton({
                 // Trigger sparkle only when starring (not unstarring)
                 if (!isStarred) {
                     triggerSparkle();
+                    triggerHaptic("medium"); // Tactile feedback on starring
+                } else {
+                    triggerHaptic("light"); // Lighter feedback on unstarring
                 }
                 onToggle();
             }}

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -11,6 +11,7 @@ import {
     copyMarkdown,
     copyPlainText,
 } from "@/lib/copy-utils";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -158,6 +159,7 @@ export function CopyButton({
     const [isOpen, setIsOpen] = useState(false);
     const copiedTimeoutRef = useRef<NodeJS.Timeout | null>(null);
     const { currentMessage, triggerDelight, scheduleClear } = useCopyDelight();
+    const { triggerHaptic } = useHapticFeedback();
 
     // Cleanup timeout on unmount
     useEffect(() => {
@@ -174,6 +176,7 @@ export function CopyButton({
             setCopied(mode);
             setIsOpen(false);
             triggerDelight();
+            triggerHaptic("medium"); // Tactile feedback on successful copy
             scheduleClear();
             onCopySuccess?.();
 
@@ -185,7 +188,7 @@ export function CopyButton({
                 copiedTimeoutRef.current = null;
             }, FEEDBACK_DURATION_MS);
         },
-        [triggerDelight, scheduleClear, onCopySuccess]
+        [triggerDelight, triggerHaptic, scheduleClear, onCopySuccess]
     );
 
     const handleCopy = async (mode: CopyMode) => {

--- a/components/ui/regenerate-button.tsx
+++ b/components/ui/regenerate-button.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useRef, useEffect } from "react";
 import { RotateCw } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 
 interface RegenerateButtonProps {
     /**
@@ -47,6 +48,7 @@ export function RegenerateButton({
 }: RegenerateButtonProps) {
     const [isAnimating, setIsAnimating] = useState(false);
     const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+    const { triggerHaptic } = useHapticFeedback();
 
     // Cleanup timeout on unmount
     useEffect(() => {
@@ -60,6 +62,7 @@ export function RegenerateButton({
     const handleClick = useCallback(async () => {
         if (disabled || isRegenerating || isAnimating) return;
 
+        triggerHaptic("light"); // Haptic feedback on regenerate
         setIsAnimating(true);
         try {
             await onRegenerate();
@@ -74,7 +77,7 @@ export function RegenerateButton({
                 timeoutRef.current = null;
             }, 500);
         }
-    }, [onRegenerate, disabled, isRegenerating, isAnimating]);
+    }, [onRegenerate, disabled, isRegenerating, isAnimating, triggerHaptic]);
 
     const isSpinning = isAnimating || isRegenerating;
 

--- a/components/ui/theme-switcher.tsx
+++ b/components/ui/theme-switcher.tsx
@@ -6,6 +6,7 @@ import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
 import { Button } from "./button";
+import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 
 // Track whether we're on the client
 const subscribe = () => () => {};
@@ -33,8 +34,10 @@ export function ThemeSwitcher({
 }: ThemeSwitcherProps = {}) {
     const isClient = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
     const { resolvedTheme, setTheme } = useTheme();
+    const { triggerHaptic } = useHapticFeedback();
 
     const toggleTheme = () => {
+        triggerHaptic("light"); // Tactile feedback on theme switch
         setTheme(resolvedTheme === "dark" ? "light" : "dark");
     };
 

--- a/lib/hooks/use-haptic-feedback.ts
+++ b/lib/hooks/use-haptic-feedback.ts
@@ -1,0 +1,167 @@
+/**
+ * Haptic Feedback Hook
+ *
+ * Provides unified haptic feedback API for mobile devices.
+ * Uses Vibration API on Android/Chrome, hidden checkbox workaround on iOS 18+ Safari.
+ *
+ * Gracefully degrades to no-op on unsupported devices.
+ * Respects device settings automatically.
+ */
+
+"use client";
+
+import { useCallback, useRef } from "react";
+
+export type HapticType =
+    | "light" // 30ms - routine button presses, selections
+    | "medium" // 50ms - significant actions (star, copy success)
+    | "heavy" // 100ms - emphasis, important confirmations
+    | "success" // pattern - successful completion
+    | "error" // pattern - errors, failures
+    | "selection"; // 20ms - slider/toggle changes
+
+const HAPTIC_PATTERNS: Record<HapticType, number | number[]> = {
+    light: 30,
+    medium: 50,
+    heavy: 100,
+    success: [30, 60, 30],
+    error: [50, 30, 50, 30, 50],
+    selection: 20,
+};
+
+function detectIOSSafari(): boolean {
+    if (typeof navigator === "undefined") return false;
+    const ua = navigator.userAgent;
+    const isIOS = /iPad|iPhone|iPod/.test(ua) && !("MSStream" in window);
+    const isSafari = /Safari/.test(ua) && !/CriOS|FxiOS|OPiOS|EdgiOS/.test(ua);
+    return isIOS && isSafari;
+}
+
+function detectVibrationSupport(): boolean {
+    return typeof navigator !== "undefined" && "vibrate" in navigator;
+}
+
+/**
+ * Trigger haptic feedback on iOS 18+ Safari using the checkbox switch workaround.
+ * Safari triggers haptic feedback when toggling input[type="checkbox"][switch].
+ */
+function triggerIOSHaptic(): void {
+    try {
+        const checkbox = document.createElement("input");
+        checkbox.type = "checkbox";
+        checkbox.setAttribute("switch", "");
+        checkbox.style.cssText =
+            "position:absolute;opacity:0;pointer-events:none;width:0;height:0;";
+
+        const label = document.createElement("label");
+        label.appendChild(checkbox);
+        document.body.appendChild(label);
+
+        // Trigger the haptic by clicking the label
+        label.click();
+
+        // Clean up immediately
+        requestAnimationFrame(() => {
+            label.remove();
+        });
+    } catch {
+        // Silently fail - haptics are non-critical
+    }
+}
+
+export interface UseHapticFeedbackReturn {
+    /**
+     * Trigger haptic feedback of the specified type.
+     * No-op on unsupported devices.
+     */
+    trigger: (type: HapticType) => void;
+    /**
+     * Alias for trigger - more descriptive name.
+     */
+    triggerHaptic: (type: HapticType) => void;
+    /**
+     * Stop any ongoing vibration pattern (Android only).
+     */
+    stop: () => void;
+    /**
+     * Whether haptic feedback is supported on this device.
+     */
+    isSupported: boolean;
+}
+
+export function useHapticFeedback(): UseHapticFeedbackReturn {
+    const isIOSRef = useRef<boolean | null>(null);
+    const hasVibrateRef = useRef<boolean | null>(null);
+
+    // Lazy initialization to avoid SSR issues
+    const getCapabilities = useCallback(() => {
+        if (isIOSRef.current === null) {
+            isIOSRef.current = detectIOSSafari();
+        }
+        if (hasVibrateRef.current === null) {
+            hasVibrateRef.current = detectVibrationSupport();
+        }
+        return {
+            isIOS: isIOSRef.current,
+            hasVibrate: hasVibrateRef.current,
+        };
+    }, []);
+
+    const trigger = useCallback(
+        (type: HapticType) => {
+            const { isIOS, hasVibrate } = getCapabilities();
+
+            if (hasVibrate) {
+                // Android/Chrome - use Vibration API
+                try {
+                    navigator.vibrate(HAPTIC_PATTERNS[type]);
+                } catch {
+                    // Silently fail
+                }
+            } else if (isIOS) {
+                // iOS Safari - use checkbox workaround
+                // Note: iOS workaround doesn't support patterns/duration
+                // All haptics trigger as single tap on iOS
+                triggerIOSHaptic();
+            }
+            // Unsupported devices: silently no-op
+        },
+        [getCapabilities]
+    );
+
+    const stop = useCallback(() => {
+        const { hasVibrate } = getCapabilities();
+        if (hasVibrate) {
+            try {
+                navigator.vibrate(0);
+            } catch {
+                // Silently fail
+            }
+        }
+    }, [getCapabilities]);
+
+    const isSupported =
+        typeof window !== "undefined" &&
+        (detectVibrationSupport() || detectIOSSafari());
+
+    return { trigger, triggerHaptic: trigger, stop, isSupported };
+}
+
+/**
+ * Standalone trigger function for use outside React components.
+ * Useful for event handlers that don't have hook access.
+ */
+export function triggerHaptic(type: HapticType): void {
+    const hasVibrate = detectVibrationSupport();
+    const isIOS = detectIOSSafari();
+
+    if (hasVibrate) {
+        try {
+            navigator.vibrate(HAPTIC_PATTERNS[type]);
+        } catch {
+            // Silently fail
+        }
+    } else if (isIOS) {
+        triggerIOSHaptic();
+    }
+}


### PR DESCRIPTION
## Summary

Adds tactile haptic feedback on mobile devices to make interactions feel more physical and satisfying, as requested in #369.

- **Zero external dependencies** - Uses native Vibration API (Android/Chrome) with iOS 18+ Safari workaround
- **Unified `useHapticFeedback` hook** - Clean React hook API with standalone function export for non-component contexts
- **Graceful fallback** - No-op on unsupported devices, SSR-safe
- **Thoughtful haptic hierarchy** - Different intensities match action importance

### Integration Points

| Action | Haptic Type | Notes |
|--------|-------------|-------|
| Send message | `medium` | Primary action, strong confirmation |
| Copy success | `medium` | Significant action, celebrate success |
| Model selection | `medium` | Important choice, confirm clearly |
| Star/pin | `medium` | Celebration moment |
| Unstar/unpin | `light` | Subtle removal confirmation |
| Theme switch | `light` | Frequent action, subtle |
| Regenerate | `light` | Request action |
| Stop generation | `light` | Cancel action |
| Slider change | `selection` | Rapid interactions need minimal feedback |
| Error appears | `error` | Distinct pattern for attention |

### Technical Notes

- **iOS limitation**: Safari's checkbox switch workaround doesn't support patterns/duration - all haptics feel as single tap on iOS
- **Pattern definitions**: `light` (30ms), `medium` (50ms), `heavy` (100ms), `selection` (20ms), `success` (pattern), `error` (pattern)
- **Respects device settings** - Haptics automatically disabled in Low Power Mode, etc.

## Test Plan

- [ ] Send message triggers haptic on mobile
- [ ] Copy button success triggers haptic
- [ ] Star/unstar conversations trigger different haptic intensities
- [ ] Model selection triggers haptic
- [ ] Slider adjustments trigger rapid selection haptics
- [ ] Error banner appearance triggers error pattern
- [ ] No haptics on desktop browsers
- [ ] No console errors on unsupported devices

Fixes #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)