### PR TITLE
⌨️ Chat Input Polish

### DIFF
--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -191,10 +191,7 @@ function HoloThreadInner() {
                     }}
                 >
                     <ScrollToBottomButton />
-                    <Composer
-                        isNewConversation={isEmpty}
-                        onMarkMessageStopped={handleMarkMessageStopped}
-                    />
+                    <Composer onMarkMessageStopped={handleMarkMessageStopped} />
                 </motion.div>
             </div>
         </StickToBottom>
@@ -1696,17 +1693,17 @@ function PendingAssistantMessage({
  * - Enter = send, Shift+Enter = newline, Escape = stop
  * - IME composition detection (prevents sending mid-composition)
  * - Stop returns last message to input for quick correction
- * - Smart autofocus: new conversations always focus, existing on mobile don't
+ * - Autofocus on mount (all devices), re-focus after send
+ * - One-time Shift+Enter hint for new users
  */
 interface ComposerProps {
-    isNewConversation: boolean;
     /** Callback to mark a message as stopped (for visual indicator) */
     onMarkMessageStopped: (messageId: string) => void;
 }
 
 const SHIFT_ENTER_HINT_KEY = "carmenta:shift-enter-hint-shown";
 
-function Composer({ isNewConversation, onMarkMessageStopped }: ComposerProps) {
+function Composer({ onMarkMessageStopped }: ComposerProps) {
     const { overrides, setOverrides } = useModelOverrides();
     const { concierge, setConcierge } = useConcierge();
     const { messages, append, isLoading, stop, input, setInput, handleInputChange } =


### PR DESCRIPTION
## Summary
- **Auto-focus on all devices**: Input now focuses on page load for mobile users too (per user preference)
- **Re-focus after send**: Input automatically refocuses after sending a message for quick follow-ups
- **One-time Shift+Enter hint**: New users see a subtle tip about using Shift+Enter for new lines, which auto-dismisses after 5 seconds and never shows again

Fixes #357

## Test plan
- [ ] Verify input auto-focuses on desktop page load
- [ ] Verify input auto-focuses on mobile (keyboard appears)
- [ ] Send a message and verify input refocuses for follow-up
- [ ] Clear localStorage and verify Shift+Enter hint appears
- [ ] Verify hint auto-dismisses after 5 seconds
- [ ] Refresh and verify hint doesn't appear again

🤖 Generated with [Claude Code](https://claude.com/claude-code)