### PR TITLE
🐛 Fix user menu dropdown blocked by stacking context

### DIFF
--- a/components/connection/connect-layout.tsx
+++ b/components/connection/connect-layout.tsx
@@ -151,12 +151,30 @@ function ConnectLayoutInner({ children }: { children: ReactNode }) {
                             {showConnectionChooser && <ConnectionChooser />}
                         </motion.div>
 
-                        {/* Account */}
+                        {/* Account - User dropdown menu
+
+                            ⚠️ CRITICAL Z-INDEX WARNING ⚠️
+
+                            This motion.div creates a stacking context because Framer Motion
+                            applies CSS transforms during animation. Without an explicit z-index,
+                            this stacking context defaults to z-auto (effectively 0).
+
+                            The <main> element below has z-base (0). Since main comes AFTER
+                            header in DOM order, main wins when z-indices are equal - blocking
+                            ALL clicks on the UserAuthButton dropdown menu.
+
+                            z-dropdown (30) ensures the dropdown renders above main content.
+                            DO NOT REMOVE THIS Z-INDEX or the dropdown will be unclickable.
+
+                            Bug was caused by: Framer Motion transform + DOM order + equal z-index
+                            See: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context
+                        */}
                         <motion.div
                             variants={entranceVariants}
                             initial="hidden"
                             animate="visible"
                             custom={0.1}
+                            className="z-dropdown"
                         >
                             <UserAuthButton />
                         </motion.div>


### PR DESCRIPTION
## Summary

- **Root cause**: Framer Motion's entrance animation creates a stacking context (via CSS transforms) on the motion.div wrapper around UserAuthButton, but without an explicit z-index it defaults to auto (0)
- **Why it broke**: The `<main>` element has z-base (0) and comes AFTER header in DOM order - when stacking contexts have equal z-index, later DOM order wins
- **Fix**: Add `z-dropdown` (30) to the motion.div wrapper so the dropdown's stacking context renders above main content

This is a DIFFERENT bug from the pointer-events-none fix in f6a9212. That fix addressed hover backgrounds blocking clicks WITHIN menu items. This fix addresses the ENTIRE dropdown being blocked by main content.

## Test plan

- [x] Open /connection page
- [x] Click user avatar in top right
- [x] Click any menu item (Knowledge Base, Guide, Integrations, etc.)
- [x] Verify navigation works (was completely broken before)
- [x] All 1480 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)