### PR TITLE
🚀 Add Vercel deployment script with docs sync

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "analyze": "ANALYZE=true next build",
     "build": "next build",
+    "vercel-build": "bash ./scripts/vercel-deploy.sh",
     "dev": "next dev --turbopack",
     "dev:debug": "NODE_OPTIONS='--inspect' next dev --turbopack",
     "db:generate": "drizzle-kit generate",

--- a/scripts/vercel-deploy.sh
+++ b/scripts/vercel-deploy.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Vercel deployment script for Carmenta
+# Package management: pnpm
+# Runtime: Node.js
+# Database: Supabase Postgres (external)
+
+set -e  # Exit on error
+
+echo "🚀 Starting Carmenta deployment..."
+echo "   Node version (runtime): $(node --version)"
+echo "   pnpm version (packages): $(pnpm --version)"
+
+# Sync documentation to knowledge base
+echo "📚 Syncing system documentation..."
+pnpm run docs:sync || { echo "❌ Docs sync failed"; exit 1; }
+
+# Build the application
+echo "🏗️  Building application..."
+pnpm run build
+
+echo "✅ Deployment build complete!"


### PR DESCRIPTION
## Summary

Fixes blank guide page by ensuring documentation is synced to the database during Vercel deployments.

## Problem

The guide page (`/guide`) was showing "No documentation yet" because the documentation files in `/docs` weren't being synced to the database. We previously had this in `render-deploy.sh` when using Render, but lost it during the migration to Vercel.

## Solution

Created `scripts/vercel-deploy.sh` that:
1. Syncs `/docs` markdown files to database (with smart skipping if up-to-date)
2. Builds Next.js production bundle
3. Provides clear logging at each step

Added `vercel-build` script to package.json that Vercel automatically runs during deployment.

## Changes

- ✨ Add `scripts/vercel-deploy.sh`: Deployment script based on old `render-deploy.sh`
- 🔧 Add `vercel-build` to package.json: Hooks into Vercel's build process

## Technical Details

- Uses `bash` invocation for portability (doesn't rely on executable permission bits)
- Script uses `set -e` for proper error handling
- Docs sync has explicit error handling with clear failure messages
- Smart sync optimization: skips if docs haven't changed since last sync

## Testing

- ✅ Local build test: `pnpm vercel-build` successfully syncs and builds
- ✅ Code review: Addressed security and error handling concerns from ai-coding-config:code-reviewer
- ✅ All tests pass (1510 passed)
- ✅ Type checking passes
- ✅ Formatting passes

## Review Notes

Based on the old `render-deploy.sh` pattern but simplified for Vercel (removed Render-specific steps like copying static assets for standalone mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)