### PR TITLE
🐛 Fix PWA gesture hooks per Cursor Bugbot feedback

### DIFF
--- a/lib/hooks/use-install-prompt.ts
+++ b/lib/hooks/use-install-prompt.ts
@@ -124,6 +124,8 @@ export function useInstallPrompt(): UseInstallPromptReturn {
             return outcome;
         } catch (error) {
             logger.error({ error }, "📲 Install prompt failed");
+            // Clear the prompt - it's now unusable after error
+            setDeferredPrompt(null);
             return "unavailable";
         }
     }, [deferredPrompt]);


### PR DESCRIPTION
## Summary

Follow-up fixes for PR #427 (PWA Mobile Enhancements) based on Cursor Bugbot feedback:

- **Event listener performance**: Fixed callback recreation on every touch move frame by using refs for threshold comparison instead of state in dependency arrays
- **Swipe navigation error handling**: Added try-finally to ensure state always resets, even if onBack throws
- **Install prompt cleanup**: Clear deferredPrompt on error since it becomes unusable after failure
- **Lint fix**: Wrapped triggerHaptic no-op in useCallback to fix exhaustive-deps warnings

## Test plan

- [x] Type check passes
- [x] Lint passes (104 warnings, all pre-existing)
- [x] All 1510 tests pass
- [ ] Manual test: Pull-to-refresh gesture should work smoothly without performance issues
- [ ] Manual test: Swipe-back navigation should reset state even on navigation errors
- [ ] Manual test: Install prompt should clear after any error

## Context

Addresses remaining Cursor Bugbot comments from PR #427:
- https://github.com/carmentacollective/carmenta/pull/427#discussion_r2647166605
- https://github.com/carmentacollective/carmenta/pull/427#discussion_r2647166607
- https://github.com/carmentacollective/carmenta/pull/427#discussion_r2647166610

🤖 Generated with [Claude Code](https://claude.com/claude-code)