### PR TITLE
📊 Add bundle size tracking to CI pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,34 @@ jobs:
           echo "✅ Build successful! Output directory size:"
           du -sh .next
 
+      - name: 📊 Analyze bundle size
+        id: bundle
+        run: |
+          # Extract bundle sizes from Next.js build output
+          # Look for the client-side JS in static/chunks
+          TOTAL_SIZE=$(find .next/static/chunks -name "*.js" -exec cat {} + | wc -c)
+          TOTAL_KB=$((TOTAL_SIZE / 1024))
+
+          # Count individual chunk files
+          CHUNK_COUNT=$(find .next/static/chunks -name "*.js" | wc -l)
+
+          # Find the main app bundle
+          MAIN_BUNDLE=$(find .next/static/chunks -name "main-*.js" -exec du -k {} + | cut -f1 | head -1 || echo "0")
+
+          echo "## 📊 Bundle Size Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Metric | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|--------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Total JS (uncompressed) | ${TOTAL_KB} KB |" >> $GITHUB_STEP_SUMMARY
+          echo "| Chunk count | ${CHUNK_COUNT} files |" >> $GITHUB_STEP_SUMMARY
+          echo "| Main bundle | ${MAIN_BUNDLE} KB |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_Run \`pnpm next experimental-analyze\` locally for detailed treemap_" >> $GITHUB_STEP_SUMMARY
+
+          # Output for potential future PR comment action
+          echo "total_kb=${TOTAL_KB}" >> $GITHUB_OUTPUT
+          echo "chunk_count=${CHUNK_COUNT}" >> $GITHUB_OUTPUT
+
       - name: 📦 Create artifact bundle
         run: |
           # Create tarball to bypass .gitignore restrictions in upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     ]
   },
   "scripts": {
-    "analyze": "ANALYZE=true next build",
+    "analyze": "next experimental-analyze",
+    "analyze:webpack": "ANALYZE=true next build --webpack",
     "build": "next build",
     "dev": "next dev --turbopack",
     "dev:debug": "NODE_OPTIONS='--inspect' next dev --turbopack",


### PR DESCRIPTION
## Summary

- Add bundle size report to GitHub Actions job summary after each build
- Update `pnpm analyze` to use Turbopack-compatible `next experimental-analyze`
- Add `pnpm analyze:webpack` for legacy webpack-based analysis

## What this does

Every build now reports bundle metrics in the GitHub Actions job summary:
- Total JS size (uncompressed)
- Number of chunks
- Main bundle size

The outputs (`total_kb`, `chunk_count`) are available for future PR comment automation.

## Current bundle state

Based on local analysis:
- **862 KB compressed** (2.43 MB uncompressed)
- **520 modules** across all routes
- Biggest contributors: PostHog (107KB), Zod (188KB), Clerk (~80KB)

## Test plan

- [x] Pre-push hooks pass (type-check, format, 1510 tests)
- [ ] CI build completes and shows bundle report in job summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)