### PR TITLE
Fix duplicate "About You" labels in Knowledge Base navigation

### DIFF
--- a/app/knowledge-base/page.tsx
+++ b/app/knowledge-base/page.tsx
@@ -64,12 +64,12 @@ export default async function KnowledgeBasePage() {
         getRecentActivity(),
     ]);
 
-    // Build folder structure: About You, Communication, Memories
+    // Build folder structure: Profile, Communication, Memories
     // Philosophy (Heart-Centered AI) is displayed on dedicated /philosophy page
     const allFolders: KBFolder[] = [];
     const profileFolder = userFolders.find((f) => f.path === "profile");
 
-    // 1. About You - personal identity info
+    // 1. Profile - personal identity info (displays as "About You" document)
     if (profileFolder) {
         const identityDoc = profileFolder.documents.find(
             (d) => d.path === "profile.identity"

--- a/components/knowledge-viewer/kb-sidebar.tsx
+++ b/components/knowledge-viewer/kb-sidebar.tsx
@@ -30,7 +30,7 @@ const FOLDER_ICONS: Record<string, typeof User> = {
 
 // Display names for folders
 const FOLDER_DISPLAY_NAMES: Partial<Record<string, string>> = {
-    about: "About You",
+    about: "Profile",
     communication: "Communication",
     memories: "Memories",
 };


### PR DESCRIPTION
## Summary

Fixes the confusing UX where three navigation items were all labeled "About You" in the Knowledge Base sidebar.

**Before:** Three items labeled "About You"
- "About You" folder (hardcoded display name)
- "About You" document inside (user's identity info)
- "About You" under Memories (knowledge document)

**After:** Clear hierarchy
- "Profile" folder (renamed)
- "About You" document inside
- "About You" under Memories (user data, unchanged)

## Changes

- Renamed sidebar folder display name from "About You" to "Profile" in `kb-sidebar.tsx`
- Updated comments in `page.tsx` to reflect new naming

## Why "Profile"?

The folder contains the user's personal identity information. "Profile" is:
- Semantically accurate (it's their profile data)
- Clearly different from the document name "About You"
- Consistent with common UX patterns (profile sections)

## Testing

- TypeScript type checking passes
- All 1510 unit/integration tests pass
- Manual verification: sidebar now shows "Profile" as the folder with "About You" as the document inside

Fixes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)