### PR TITLE
🐛 Fix Combined Options test assertion

### DIFF
--- a/__tests__/integration/lib/ai/gateway.integration.test.ts
+++ b/__tests__/integration/lib/ai/gateway.integration.test.ts
@@ -301,7 +301,7 @@ describeIf("Vercel AI Gateway Integration", () => {
                     cacheControl: { type: "ephemeral" },
                 },
                 gateway: {
-                    models: ["google/gemini-3-pro-preview"],
+                    models: ["google/gemini-3.0-pro-preview"], // Translated
                 },
             });
         });


### PR DESCRIPTION
## Summary

Fixes test assertion that Cursor Bugbot correctly identified on PR #442.

The "Combined Options" test expected an untranslated model ID in the fallback list, but since we now translate fallback models in `translateFallbackOptions()`, it should expect the translated value.

**Fixed:**
- Changed expected `google/gemini-3-pro-preview` → `google/gemini-3.0-pro-preview`

## Test plan

- [x] All 1510 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)