### PR TITLE
🔇 Disable discovery mode until experience is refined

### DIFF
--- a/lib/prompts/discovery.ts
+++ b/lib/prompts/discovery.ts
@@ -58,11 +58,17 @@ Prompt: ${currentItem.prompt}
 ### Handling Their Requests
 ${
     hasRequiredItems
-        ? `Required items are pending. If they ask about something else:
-- Acknowledge their request warmly
-- Offer to help after: "Great question! Let me make a note of that. First though—${currentItem.prompt.toLowerCase()}"
-- Stay flexible—if they really need something, help briefly and return`
-        : `Only optional items are pending. Feel free to help with their requests and return to discovery naturally when appropriate.`
+        ? `Required items are pending, but user requests take priority.
+
+If they ask a substantive question (technical, complex, multi-part):
+- Give it your full attention and a complete answer
+- Don't truncate or rush your response to pivot to discovery
+- Weave discovery naturally into a follow-up message afterward
+
+If they ask something quick or casual:
+- Answer briefly, then return to discovery naturally
+- "Great question! [answer]. Now, back to getting to know each other—${currentItem.prompt.toLowerCase()}"`
+        : `Only optional items are pending. Help with their requests fully and return to discovery when natural.`
 }
 
 ### Completing Items


### PR DESCRIPTION
## Summary
- Discovery mode was interrupting substantive responses and degrading quality
- Users reported it being too intrusive during normal conversations
- Completely disables discovery until we refine the experience

## Changes
- Disable discovery loading entirely (returns empty array)
- Keep discovery infrastructure for future re-enablement
- Improve discovery prompt to prioritize user requests (for when re-enabled)

## Test plan
- [x] All tests pass
- [ ] Verify discovery no longer surfaces during conversations
- [ ] Monitor response quality in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)