### PR TITLE
🐛 Fix mobile search input stealing focus from chat composer

### DIFF
--- a/components/connection/connection-chooser.tsx
+++ b/components/connection/connection-chooser.tsx
@@ -732,14 +732,18 @@ export function ConnectionChooser({
         [activeConnection, updateConnectionTitle]
     );
 
-    // Focus input when dropdown opens
+    const isMobilePlacement = placement === "bottom";
+
+    // Focus search input when dropdown opens on desktop only
+    // On mobile (bottom placement), skip auto-focus to avoid disruptive keyboard popup
+    // when user accidentally taps the dropdown trigger near the chat input
     useEffect(() => {
-        if (isDropdownOpen && inputRef.current) {
+        if (isDropdownOpen && inputRef.current && !isMobilePlacement) {
             requestAnimationFrame(() => {
                 inputRef.current?.focus();
             });
         }
-    }, [isDropdownOpen]);
+    }, [isDropdownOpen, isMobilePlacement]);
 
     // Keyboard shortcut: Cmd+Shift+S to toggle star on active connection
     useEffect(() => {
@@ -769,8 +773,6 @@ export function ConnectionChooser({
     // Unified container - smooth transitions between states
     // Mobile (bottom placement): full width, plus on right
     // Desktop (header placement): use glass-pill styling
-    const isMobilePlacement = placement === "bottom";
-
     return (
         <div className={cn("relative", isMobilePlacement && "w-full")}>
             <motion.div


### PR DESCRIPTION
## Summary
- Fixes focus being stolen from chat input when user taps while Carmenta is thinking on iPhone
- Disables auto-focus of search input on mobile (bottom placement) while preserving desktop behavior
- Root cause: tapping chat input near dropdown trigger during streaming (when RunningIndicator causes layout shift) could accidentally open dropdown, which then auto-focused the search input

## Test plan
- [x] Verified on mobile viewport (390x844): dropdown opens but search does NOT auto-focus
- [x] Verified on desktop viewport: search still auto-focuses (preserves keyboard navigation UX)
- [x] All 1490 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)