### PR TITLE
fix: Move useOptimistic update inside startTransition

### DIFF
--- a/components/connection/connection-context.tsx
+++ b/components/connection/connection-context.tsx
@@ -242,12 +242,11 @@ export function ConnectionProvider({
 
             const newIsStarred = !connection.isStarred;
 
-            // React 19: useOptimistic provides instant UI update
-            // Automatically reverts if the async action below fails
-            updateOptimisticConnections({ id, isStarred: newIsStarred });
-
-            // Server action with transition for proper pending state
+            // React 19: useOptimistic update MUST be inside startTransition
             startTransition(async () => {
+                // Optimistic update for instant UI feedback
+                updateOptimisticConnections({ id, isStarred: newIsStarred });
+
                 try {
                     const updated = await toggleStarAction(id, newIsStarred);
                     // Sync real state on success
@@ -261,7 +260,7 @@ export function ConnectionProvider({
                         "Toggled star"
                     );
                 } catch (err) {
-                    // useOptimistic auto-reverts, but we still need to show the error
+                    // useOptimistic auto-reverts on error
                     const error = err instanceof Error ? err : new Error(String(err));
                     logger.error({ error, connectionId: id }, "Failed to toggle star");
                     setError(error);


### PR DESCRIPTION
## Summary

- Fixed React 19 `useOptimistic` error when starring/unstarring connections
- Moved `updateOptimisticConnections` call inside `startTransition` as required by React 19

## Problem

The star toggle was causing this React error:
> "An optimistic state update occurred outside a transition or action"

This could cause intermittent failures with star/unstar, especially at the top of the connection chooser where animations are more prominent.

## Solution

React 19's `useOptimistic` requires the optimistic update to be called within a transition or action context. The fix moves the call inside `startTransition` while maintaining instant UI feedback (startTransition executes synchronously - only the async work is tracked).

## Test plan

- [ ] Open connection chooser dropdown
- [ ] Star a connection → should move to "Starred" section at top
- [ ] Unstar the connection → should move back to "Recent" section  
- [ ] Verify no console errors about "optimistic state update outside transition"
- [ ] Rapid-fire toggle the star button to test race conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)