### PR TITLE
🏗️ Clara: Comprehensive z-index audit and framework improvements

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -76,6 +76,7 @@
         --z-modal: 50;
         --z-tooltip: 50;
         --z-toast: 60;
+        --z-loading: 70;
     }
 
     /* Dark mode - Cosmic consciousness depths with ethereal shimmer */

--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -18,7 +18,7 @@
 
 export default function Loading() {
     return (
-        <div className="fixed inset-0 z-[99999] flex items-center justify-center bg-background">
+        <div className="fixed inset-0 z-loading flex items-center justify-center bg-background">
             {/* Keyframe animations and dark mode adjustments - inline to ensure they're available before CSS loads */}
             <style
                 dangerouslySetInnerHTML={{

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -5,6 +5,24 @@ UI components using TypeScript, Tailwind CSS, and Radix primitives.
 Use `cn()` from `@/lib/utils` for conditional classes. Define clear prop interfaces with
 sensible defaults. Keep components focused—loading, error, empty, and success states.
 
+## Z-Index
+
+Use semantic z-index classes, never arbitrary values. See `lib/z-index.ts` for the full
+hierarchy and guidelines. Key levels:
+
+- `z-content` (10) - Page content, relatively positioned elements
+- `z-sticky` (20) - Sticky headers, sidebars
+- `z-dropdown` (30) - Dropdown menus, select options
+- `z-backdrop` (40) - Modal backdrop overlays
+- `z-modal` (50) - Modals, dialogs, drawers, popovers
+- `z-tooltip` (50) - Tooltips (same level as modals)
+- `z-toast` (60) - Toast notifications
+- `z-loading` (70) - Full-screen blocking overlays
+
+Radix primitives portal to `<body>`, creating stacking contexts that avoid conflicts.
+For internal component layering (content above shimmer effects), low values like `z-10`
+are acceptable—these don't participate in the page-level hierarchy.
+
 ## Tooltips
 
 Use Radix `<Tooltip>` primitives for all new components. Apply semantic z-index classes:

--- a/components/benchmarks/query-detail-modal.tsx
+++ b/components/benchmarks/query-detail-modal.tsx
@@ -38,7 +38,7 @@ export function QueryDetailModal({ query, pairwise, onClose }: QueryDetailModalP
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+            className="fixed inset-0 z-modal flex items-center justify-center bg-black/60 backdrop-blur-sm"
             onClick={onClose}
         >
             <div

--- a/components/pwa/pull-to-refresh-indicator.tsx
+++ b/components/pwa/pull-to-refresh-indicator.tsx
@@ -47,7 +47,7 @@ export function PullToRefreshIndicator({
             }}
             exit={{ opacity: 0, scale: 0.5 }}
             transition={{ type: "spring", damping: 20, stiffness: 300 }}
-            className="pointer-events-none fixed left-1/2 top-0 z-50 -translate-x-1/2"
+            className="pointer-events-none fixed left-1/2 top-0 z-modal -translate-x-1/2"
         >
             <div
                 className={cn(

--- a/components/pwa/swipe-back-indicator.tsx
+++ b/components/pwa/swipe-back-indicator.tsx
@@ -40,7 +40,7 @@ export function SwipeBackIndicator({
                     }}
                     exit={{ opacity: 0, x: -20 }}
                     transition={{ type: "spring", damping: 25, stiffness: 300 }}
-                    className="pointer-events-none fixed left-0 top-1/2 z-50 -translate-y-1/2"
+                    className="pointer-events-none fixed left-0 top-1/2 z-modal -translate-y-1/2"
                 >
                     <div
                         className={cn(

--- a/components/ui/global-tooltip.tsx
+++ b/components/ui/global-tooltip.tsx
@@ -18,7 +18,7 @@ export function GlobalTooltip() {
             place="top"
             delayShow={400}
             delayHide={100}
-            className="!z-[100] !max-w-xs !rounded-lg !border !border-border/50 !bg-popover !px-3 !py-2 !text-sm !text-popover-foreground !shadow-lg !backdrop-blur-md"
+            className="!z-tooltip !max-w-xs !rounded-lg !border !border-border/50 !bg-popover !px-3 !py-2 !text-sm !text-popover-foreground !shadow-lg !backdrop-blur-md"
             classNameArrow="!border-border/50"
             opacity={1}
         />

--- a/components/ui/oracle-whisper.tsx
+++ b/components/ui/oracle-whisper.tsx
@@ -294,7 +294,7 @@ export function OracleWhisper({ className }: OracleWhisperProps) {
                             delay: 0.6,
                             ease: [0.23, 1, 0.32, 1],
                         }}
-                        className="absolute left-1/2 top-full z-50 mt-3 w-56 -translate-x-1/2 sm:w-72"
+                        className="absolute left-1/2 top-full z-modal mt-3 w-56 -translate-x-1/2 sm:w-72"
                     >
                         {/* Speech tail pointing up to Oracle */}
                         <div className="absolute -top-2 left-6 h-4 w-4 rotate-45 border-l border-t border-white/20 bg-white/70 backdrop-blur-xl dark:border-white/10 dark:bg-black/50" />

--- a/lib/z-index.ts
+++ b/lib/z-index.ts
@@ -16,6 +16,7 @@
  * | z-modal     | 50    | Modals, dialogs, drawers, popovers        |
  * | z-tooltip   | 50    | Tooltips (same level as modals)           |
  * | z-toast     | 60    | Toast notifications (always visible)      |
+ * | z-loading   | 70    | Full-screen loading/blocking overlays     |
  *
  * ## Usage Guidelines
  *
@@ -39,6 +40,10 @@
  *
  * **z-toast**: Toast notifications always appear above everything else so users
  * see important feedback even when a modal is open.
+ *
+ * **z-loading**: Full-screen loading overlays and blocking states. These are rare
+ * but critical—page transitions, initial hydration, and states where the entire
+ * UI should be blocked. Use sparingly; most loading states should be inline.
  *
  * ## Stacking Contexts
  *
@@ -65,6 +70,7 @@ export const Z_INDEX = {
     modal: 50,
     tooltip: 50,
     toast: 60,
+    loading: 70,
 } as const;
 
 export type ZIndexLevel = keyof typeof Z_INDEX;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -91,6 +91,7 @@ const config: Config = {
              * modal (50)   - Modals, dialogs, drawers, popovers
              * tooltip (50) - Tooltips (same level as modals)
              * toast (60)   - Toast notifications (always visible)
+             * loading (70) - Full-screen loading/blocking overlays
              */
             zIndex: {
                 base: "0",
@@ -101,6 +102,7 @@ const config: Config = {
                 modal: "50",
                 tooltip: "50",
                 toast: "60",
+                loading: "70",
             },
             keyframes: {
                 "fade-in": {


### PR DESCRIPTION
## Summary

Clara reported recurring z-index issues - this PR addresses them comprehensively.

- **Added `z-loading` (70)** for full-screen blocking states - the missing level that led to `z-[99999]`
- **Fixed 6 violations** converting arbitrary/numeric values to semantic classes
- **Added z-index quick reference** to `components/CLAUDE.md` pointing to `lib/z-index.ts`

## Changes

| File | Before | After |
|------|--------|-------|
| `app/loading.tsx` | `z-[99999]` | `z-loading` |
| `components/ui/global-tooltip.tsx` | `!z-[100]` | `!z-tooltip` |
| `components/pwa/pull-to-refresh-indicator.tsx` | `z-50` | `z-modal` |
| `components/pwa/swipe-back-indicator.tsx` | `z-50` | `z-modal` |
| `components/benchmarks/query-detail-modal.tsx` | `z-50` | `z-modal` |
| `components/ui/oracle-whisper.tsx` | `z-50` | `z-modal` |

## Test plan

- [x] Type check passes
- [x] All tests pass (1453 tests)
- [x] Prettier check passes
- [ ] Manual: Verify loading overlay appears above all content
- [ ] Manual: Verify tooltips appear correctly in modals
- [ ] Manual: Verify PWA indicators (pull-to-refresh, swipe-back) appear above content

🤖 Generated with [Claude Code](https://claude.com/claude-code)