### PR TITLE
✨ Add calculate tool renderer and defensive stream resume checks

### DIFF
--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -468,6 +468,13 @@ function getToolError(
  * Render a single tool part with the appropriate UI component
  */
 function ToolPartRenderer({ part }: { part: ToolPart }) {
+    // Defensive check - part should never be undefined given our type guard,
+    // but the AI SDK's stream resume can produce unexpected data structures
+    if (!part || typeof part !== "object" || !part.type || !part.state) {
+        logger.warn({ part }, "ToolPartRenderer received invalid part");
+        return null;
+    }
+
     const toolName = part.type.replace("tool-", "");
     const status = getToolStatus(part.state);
     const input = part.input as Record<string, unknown>;
@@ -994,6 +1001,39 @@ function ToolPartRenderer({ part }: { part: ToolPart }) {
                             initialZoom={zoom}
                             title={title}
                         />
+                    )}
+                </ToolRenderer>
+            );
+        }
+
+        case "calculate": {
+            const calcOutput = output as
+                | { result?: unknown; explanation?: string }
+                | undefined;
+            const calcError = getToolError(part, output, "Calculation failed");
+            const hasResult =
+                status === "completed" && calcOutput?.result !== undefined;
+
+            return (
+                <ToolRenderer
+                    toolName="calculate"
+                    toolCallId={part.toolCallId}
+                    status={status}
+                    input={input}
+                    output={output}
+                    error={calcError}
+                >
+                    {hasResult && (
+                        <div className="space-y-1 text-sm">
+                            <div className="font-mono text-base font-medium">
+                                {String(calcOutput.result)}
+                            </div>
+                            {calcOutput.explanation && (
+                                <div className="text-xs text-muted-foreground">
+                                    {calcOutput.explanation}
+                                </div>
+                            )}
+                        </div>
                     )}
                 </ToolRenderer>
             );

--- a/lib/tools/tool-config.ts
+++ b/lib/tools/tool-config.ts
@@ -6,6 +6,7 @@ import {
     CloudSun,
     BookOpen,
     Sparkles,
+    Calculator,
     type LucideIcon,
 } from "lucide-react";
 import { logger } from "@/lib/client-logger";
@@ -228,6 +229,20 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
         },
     },
     // Service integrations (alphabetical order)
+    calculate: {
+        displayName: "Calculator",
+        icon: Calculator,
+        messages: {
+            pending: "Getting ready...",
+            running: "Crunching numbers...",
+            completed: "Calculation complete",
+            error: "Calculation failed",
+        },
+        delightMessages: {
+            completed: ["Got it", "Here's the answer", "Math done"],
+            fast: ["Quick math!", "Done!"],
+        },
+    },
     clickup: {
         displayName: "ClickUp",
         icon: "/logos/clickup.svg",


### PR DESCRIPTION
## Summary
- Add calculate tool config with Calculator icon and display messages (alphabetically placed in TOOL_CONFIG)
- Add calculate case to ToolPartRenderer with result and optional explanation display
- Add defensive checks in ToolPartRenderer for malformed parts during stream resume
- Add filter in toAIMessage to skip null/undefined parts from stream data

## Why
- **Calculate tool**: Console was spamming errors about missing tool renderer for "calculate" (MCP Hubby math tool)
- **Stream resume checks**: TypeError "Cannot read properties of undefined (reading 'state')" was occurring when AI SDK produces unexpected data structures during stream resume

## Code Review
Reviewed by logic-reviewer and style-reviewer agents:
- ✅ Logic: No bugs found, all patterns correct
- ✅ Style: Follows existing conventions, alphabetical ordering applied

## Test plan
- [x] All 1453 tests pass
- [x] TypeScript type checks pass
- [x] Prettier formatting passes
- [ ] Manual: Verify calculate tool renders correctly in browser
- [ ] Manual: Verify stream resume no longer throws TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add calculate tool renderer and defensive stream resume checks in `ToolPartRenderer` and `toAIMessage`.
> 
>   - **Behavior**:
>     - Add `calculate` tool config with Calculator icon and display messages in `tool-config.ts`.
>     - Add `calculate` case to `ToolPartRenderer` in `holo-thread.tsx` for result and explanation display.
>     - Add defensive checks in `ToolPartRenderer` for malformed parts during stream resume in `holo-thread.tsx`.
>     - Add filter in `toAIMessage` in `connect-runtime-provider.tsx` to skip null/undefined parts from stream data.
>   - **Misc**:
>     - Reviewed by logic-reviewer and style-reviewer agents with no bugs found and style conventions followed.
>     - All 1453 tests pass, TypeScript type checks pass, and Prettier formatting passes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 8835e9b76d29cc71b37296c580752bcbcb7720c1. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->