### PR TITLE
Remove dead code: duplicate function, unused export, commented imports

### DIFF
--- a/lib/hooks/use-pull-to-refresh.ts
+++ b/lib/hooks/use-pull-to-refresh.ts
@@ -17,7 +17,6 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-// import { useHapticFeedback } from "./use-haptic-feedback"; // TODO: Re-enable
 
 export interface UsePullToRefreshOptions {
     /** Callback when refresh is triggered */

--- a/lib/hooks/use-swipe-navigation.ts
+++ b/lib/hooks/use-swipe-navigation.ts
@@ -19,7 +19,6 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-// import { useHapticFeedback } from "./use-haptic-feedback"; // TODO: Re-enable
 
 export interface UseSwipeNavigationOptions {
     /** Width of edge detection zone in pixels (default: 20) */

--- a/lib/integrations/index.ts
+++ b/lib/integrations/index.ts
@@ -27,7 +27,6 @@ export {
     SERVICE_REGISTRY,
     getServiceById,
     getAvailableServices,
-    getConnectableServices,
     getOAuthServices,
     getApiKeyServices,
     type ServiceDefinition,

--- a/lib/integrations/services.ts
+++ b/lib/integrations/services.ts
@@ -265,16 +265,6 @@ export function getAvailableServices(includeInternal = false): ServiceDefinition
 }
 
 /**
- * Get services that can be connected
- */
-export function getConnectableServices(includeInternal = false): ServiceDefinition[] {
-    return SERVICE_REGISTRY.filter((s) => {
-        if (s.status === "internal" && !includeInternal) return false;
-        return true;
-    });
-}
-
-/**
  * Get OAuth services
  */
 export function getOAuthServices(): ServiceDefinition[] {

--- a/lib/sparks/generator.ts
+++ b/lib/sparks/generator.ts
@@ -175,7 +175,7 @@ function getIconForService(serviceId: string): LucideIcon {
 /**
  * Get current time of day for contextual suggestions
  */
-export function getTimeOfDay(): "morning" | "afternoon" | "evening" {
+function getTimeOfDay(): "morning" | "afternoon" | "evening" {
     const hour = new Date().getHours();
     if (hour < 12) return "morning";
     if (hour < 17) return "afternoon";


### PR DESCRIPTION
## Summary

- Removed `getConnectableServices` which was an exact duplicate of `getAvailableServices` (identical implementation, never called)
- Made `getTimeOfDay()` private in `lib/sparks/generator.ts` - was exported but only used internally
- Removed commented-out haptic feedback import lines from `use-pull-to-refresh.ts` and `use-swipe-navigation.ts` (kept the TODO comments explaining why haptic is disabled)

## Test plan

- [x] TypeScript type check passes
- [x] ESLint passes (no new errors)
- [x] All 1453 unit tests pass
- [x] Searched codebase to confirm `getConnectableServices` has no callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove dead code: duplicate function, unused export, and commented imports.
> 
>   - **Functions**:
>     - Removed `getConnectableServices` from `services.ts`, which was a duplicate of `getAvailableServices` and never called.
>     - Made `getTimeOfDay()` private in `generator.ts` as it was only used internally.
>   - **Imports**:
>     - Removed commented-out haptic feedback import lines from `use-pull-to-refresh.ts` and `use-swipe-navigation.ts`, retaining TODO comments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 345b761e97502177534f25735842585c6f0a48d2. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->