### PR TITLE
Improve client-side hook robustness

### DIFF
--- a/lib/hooks/use-oauth-flow-recovery.ts
+++ b/lib/hooks/use-oauth-flow-recovery.ts
@@ -11,6 +11,7 @@
  */
 
 import { useState, useEffect, useCallback } from "react";
+import { logger } from "@/lib/client-logger";
 import { getServiceById } from "@/lib/integrations/services";
 
 const OAUTH_PENDING_KEY = "carmenta:oauth_pending";
@@ -53,8 +54,8 @@ function getAbandonedServiceFromStorage(): string | null {
             return pending.service;
         }
         return null;
-    } catch {
-        // Invalid storage state - clean it up
+    } catch (error) {
+        logger.debug({ error }, "Invalid OAuth pending state, cleaning up");
         sessionStorage.removeItem(OAUTH_PENDING_KEY);
         return null;
     }


### PR DESCRIPTION
## Summary

- Add cleanup flag to `useDraftPersistence` effect to prevent race conditions when users rapidly switch connections - stale async updates could fire after component unmounted or key changed
- Add debug-level logging to previously silent catch blocks in both `useDraftPersistence` and `useOAuthFlowRecovery` for better observability when localStorage/sessionStorage operations fail

## Test plan

- [x] Type check passes
- [x] All tests pass (1453 passed, 104 skipped)
- [x] Linting passes
- [ ] Manual testing: rapidly switch between connections while typing to verify no stale draft restoration

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance `useDraftPersistence` and `useOAuthFlowRecovery` hooks with cleanup flags and debug logging for improved robustness and error tracking.
> 
>   - **Behavior**:
>     - Add cleanup flag in `useDraftPersistence` to prevent race conditions when switching connections.
>     - Add debug-level logging to catch blocks in `useDraftPersistence` and `useOAuthFlowRecovery` for better error tracking.
>   - **Logging**:
>     - Log errors in `getSavedDraft()` and `clearDraft()` in `useDraftPersistence`.
>     - Log errors in `getAbandonedServiceFromStorage()` in `useOAuthFlowRecovery`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 927fa39a32ff35dd2b4a75e6fe5943c54e3ea46d. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->