### PR TITLE
Extract db instance to break circular dependencies

### DIFF
--- a/lib/db/client.ts
+++ b/lib/db/client.ts
@@ -1,0 +1,66 @@
+/**
+ * Database Client Instance
+ *
+ * Separated from index.ts to break circular dependency:
+ * Sub-modules (connections.ts, users.ts, notifications.ts) need to import
+ * the db instance, but index.ts re-exports from those sub-modules.
+ *
+ * By extracting the db instance here, sub-modules can import from client.ts
+ * without going through the barrel file.
+ *
+ * Environment:
+ * - POSTGRES_URL: Vercel Postgres connection string (preferred)
+ * - DATABASE_URL: PostgreSQL connection string (fallback)
+ * - Defaults to localhost:5432/carmenta for Mac Homebrew PostgreSQL
+ */
+
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+
+import { env } from "@/lib/env";
+import * as schema from "./schema";
+
+/**
+ * Database connection string.
+ * Prefers Vercel's POSTGRES_URL (auto-injected), falls back to DATABASE_URL.
+ */
+const connectionString = process.env.POSTGRES_URL ?? env.DATABASE_URL;
+
+/**
+ * PostgreSQL client instance.
+ *
+ * Uses the postgres.js driver which provides:
+ * - Built-in connection pooling
+ * - Prepared statements
+ * - TypeScript support
+ * - Automatic reconnection
+ */
+const client = postgres(connectionString, {
+    // Reasonable defaults for a Next.js app
+    max: 10, // Maximum pool size
+    idle_timeout: 20, // Close idle connections after 20 seconds
+    connect_timeout: 10, // Connection timeout in seconds
+});
+
+/**
+ * Drizzle ORM instance with schema.
+ *
+ * Provides:
+ * - Type-safe queries with full TypeScript inference
+ * - Relational queries via db.query
+ * - SQL builder via db.select(), db.insert(), etc.
+ *
+ * @example
+ * ```typescript
+ * // Query users by email
+ * const user = await db.query.users.findFirst({
+ *   where: eq(schema.users.email, "nick@example.com")
+ * });
+ *
+ * // Insert a new user
+ * const [newUser] = await db.insert(schema.users)
+ *   .values({ email: "nick@example.com", clerkId: "clerk_123" })
+ *   .returning();
+ * ```
+ */
+export const db = drizzle(client, { schema });

--- a/lib/db/connections.ts
+++ b/lib/db/connections.ts
@@ -7,7 +7,7 @@
 
 import { eq, desc, and } from "drizzle-orm";
 
-import { db } from "./index";
+import { db } from "./client";
 import {
     connections,
     messages,

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,68 +1,20 @@
 /**
- * Database Connection
+ * Database Module - Barrel Export
  *
- * Provides a type-safe Drizzle ORM instance connected to PostgreSQL.
- * Uses the `postgres` driver for connection pooling and query execution.
- *
- * Environment:
- * - POSTGRES_URL: Vercel Postgres connection string (preferred)
- * - DATABASE_URL: PostgreSQL connection string (fallback)
- * - Defaults to localhost:5432/carmenta for Mac Homebrew PostgreSQL
- */
-
-import { drizzle } from "drizzle-orm/postgres-js";
-import postgres from "postgres";
-
-import { env } from "@/lib/env";
-import * as schema from "./schema";
-
-/**
- * Database connection string.
- * Prefers Vercel's POSTGRES_URL (auto-injected), falls back to DATABASE_URL.
- */
-const connectionString = process.env.POSTGRES_URL ?? env.DATABASE_URL;
-
-/**
- * PostgreSQL client instance.
- *
- * Uses the postgres.js driver which provides:
- * - Built-in connection pooling
- * - Prepared statements
- * - TypeScript support
- * - Automatic reconnection
- */
-const client = postgres(connectionString, {
-    // Reasonable defaults for a Next.js app
-    max: 10, // Maximum pool size
-    idle_timeout: 20, // Close idle connections after 20 seconds
-    connect_timeout: 10, // Connection timeout in seconds
-});
-
-/**
- * Drizzle ORM instance with schema.
- *
- * Provides:
- * - Type-safe queries with full TypeScript inference
- * - Relational queries via db.query
- * - SQL builder via db.select(), db.insert(), etc.
+ * Provides a unified import point for all database operations.
+ * The db instance is defined in client.ts to break circular dependencies.
  *
  * @example
  * ```typescript
- * // Query users by email
- * const user = await db.query.users.findFirst({
- *   where: eq(schema.users.email, "nick@example.com")
- * });
- *
- * // Insert a new user
- * const [newUser] = await db.insert(schema.users)
- *   .values({ email: "nick@example.com", clerkId: "clerk_123" })
- *   .returning();
+ * import { db, schema, findUserByEmail, createConnection } from "@/lib/db";
  * ```
  */
-export const db = drizzle(client, { schema });
+
+// Re-export db instance from client (breaks circular dependency)
+export { db } from "./client";
 
 // Re-export schema for convenience
-export { schema };
+export * as schema from "./schema";
 
 // Re-export types
 export type {

--- a/lib/db/notifications.ts
+++ b/lib/db/notifications.ts
@@ -7,7 +7,8 @@
 
 import { eq, and, desc } from "drizzle-orm";
 
-import { db, schema } from "./index";
+import { db } from "./client";
+import * as schema from "./schema";
 import type { Notification, NewNotification } from "./schema";
 
 /**

--- a/lib/db/users.ts
+++ b/lib/db/users.ts
@@ -7,7 +7,9 @@
 
 import { eq } from "drizzle-orm";
 
-import { db, schema, type User, type NewUser, type UserPreferences } from "./index";
+import { db } from "./client";
+import * as schema from "./schema";
+import type { User, NewUser, UserPreferences } from "./schema";
 
 /**
  * Find a user by their email address

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -267,6 +267,24 @@ export async function getTestDb() {
 }
 
 /**
+ * Mock the client module that provides the db instance.
+ * Sub-modules import db from client.ts to break circular dependencies.
+ *
+ * Uses a getter to ensure we always get the current test db instance,
+ * not a stale reference from mock evaluation time.
+ */
+vi.mock("./lib/db/client", async () => {
+    return {
+        get db() {
+            // Dynamic lookup - returns null if no test db is set up,
+            // or the current test db instance
+            if (!testDb) return null;
+            return testDb;
+        },
+    };
+});
+
+/**
  * Global mock replaces production db with PGlite
  *
  * IMPORTANT: Never create local vi.mock("@/lib/db") calls in test files.


### PR DESCRIPTION
## Summary

- Created `lib/db/client.ts` to hold the database client instance
- Updated `lib/db/index.ts` to re-export from `client.ts` instead of defining db inline
- Updated sub-modules (`connections.ts`, `users.ts`, `notifications.ts`) to import db from `client.ts`
- Added vitest mock for `./lib/db/client` to support test database isolation

## Problem

Circular dependencies in `lib/db/`:
- `db/connections.ts` imports from `db/index.ts`
- `db/index.ts` re-exports from `db/notifications.ts` and `db/users.ts`
- `db/notifications.ts` imports from `db/index.ts`

The `db` instance was defined in `index.ts` but sub-modules needed to import it, creating the cycle.

## Solution

Extract the db instance to a dedicated `client.ts` file. Sub-modules now import db from `client.ts` instead of the barrel file. External imports via `@/lib/db` still work unchanged via re-export.

## Test plan

- [x] All 1453 unit tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] External imports (`import { db } from "@/lib/db"`) work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Extracts `db` instance to `lib/db/client.ts` to resolve circular dependencies and updates related imports and tests.
> 
>   - **Behavior**:
>     - Extracts `db` instance to `lib/db/client.ts` to resolve circular dependencies.
>     - Updates `lib/db/index.ts` to re-export `db` from `client.ts`.
>     - Updates `connections.ts`, `users.ts`, `notifications.ts` to import `db` from `client.ts`.
>   - **Testing**:
>     - Adds a Vitest mock for `lib/db/client` in `vitest.setup.ts` to support test database isolation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 07ac06c49993dd4e83aa4efe62726bc4ccd4c3df. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->