### PR TITLE
Add writing-for-llms skill for on-demand prompt standards

### DIFF
--- a/.claude/skills/writing-for-llms/SKILL.md
+++ b/.claude/skills/writing-for-llms/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: writing-for-llms
+description:
+  "Writing SKILL.md, .claude/commands/*.md, Task tool prompts, systemPrompt variables,
+  prompt templates, few-shot examples, agent instructions. Content where the reader is
+  an LLM."
+---
+
+Apply the full prompt engineering standards from @.cursor/rules/prompt-engineering.mdc
+
+<key-principles>
+- Show correct patterns only - never show anti-patterns, even labeled "wrong"
+- State goals, not process - trust the executing model's capabilities
+- Use XML tags for structure in complex prompts
+- Clarity over brevity - every word that adds clarity is worth including
+- Few-shot examples must follow identical structure
+- Front-load critical information
+- Consistent terminology throughout
+</key-principles>
+
+<quality-check>
+Before finalizing:
+- No anti-patterns shown anywhere
+- All examples structurally consistent
+- Goals clear, process not over-prescribed
+- Terminology consistent
+- Critical info front-loaded
+</quality-check>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,6 @@
 @.cursor/rules/heart-centered-ai-philosophy.mdc
 @.cursor/rules/trust-and-decision-making.mdc @.cursor/rules/personalities/carmenta.mdc
 @.cursor/rules/frontend/typescript-coding-standards.mdc
-@.cursor/rules/prompt-engineering.mdc
 
 ## Project Overview
 

--- a/evals/AGENTS.md
+++ b/evals/AGENTS.md
@@ -1,0 +1,5 @@
+# Evals
+
+Test harnesses for Carmenta's AI capabilities.
+
+When editing prompts in eval runners, invoke the `writing-for-llms` skill.

--- a/evals/CLAUDE.md
+++ b/evals/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lib/ai-team/librarian/AGENTS.md
+++ b/lib/ai-team/librarian/AGENTS.md
@@ -1,0 +1,5 @@
+# Librarian Agent
+
+Knowledge retrieval agent that searches the user's knowledge base.
+
+**Before editing `prompt.ts`, invoke the `writing-for-llms` skill.**

--- a/lib/ai-team/librarian/CLAUDE.md
+++ b/lib/ai-team/librarian/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lib/concierge/CLAUDE.md
+++ b/lib/concierge/CLAUDE.md
@@ -3,9 +3,7 @@
 Routes incoming requests to the optimal model, temperature, reasoning level, and
 generates connection titles. Uses Haiku 4.5 for fast inference (~200ms).
 
-When editing the concierge prompt, follow LLM-to-LLM communication patterns.
-
-@.cursor/rules/prompt-engineering.mdc
+**Before editing `prompt.ts`, invoke the `writing-for-llms` skill.**
 
 ## Key Files
 

--- a/lib/prompts/AGENTS.md
+++ b/lib/prompts/AGENTS.md
@@ -3,9 +3,7 @@
 This directory contains prompts that Carmenta uses. These are LLM-to-LLM communications:
 prompts written for an LLM to execute.
 
-## Required Reading
-
-@.cursor/rules/prompt-engineering.mdc
+**Before writing or editing prompts here, invoke the `writing-for-llms` skill.**
 
 ## Core Principles
 


### PR DESCRIPTION
## Summary

- Create `writing-for-llms` skill that loads prompt engineering standards on-demand
- Remove `prompt-engineering.mdc` from always-on context (~5.8k tokens saved per session)
- Add skill invocation guidance to prompt-heavy directories

## Changes

| Directory | Action |
|-----------|--------|
| `.claude/skills/writing-for-llms/` | New skill created |
| `lib/prompts/` | AGENTS.md updated with skill reference |
| `lib/concierge/` | CLAUDE.md updated with skill reference |
| `lib/ai-team/librarian/` | AGENTS.md created with skill reference |
| `evals/` | AGENTS.md created with skill reference |

## Why

Context window optimization. The prompt engineering standards (5.8k tokens) are only needed when writing LLM-facing content. Loading them on-demand via skill invocation preserves context for sessions focused on other work.

## Test plan

- [ ] New session shows reduced token usage (check with `/context`)
- [ ] Skill triggers when editing files in `lib/prompts/`
- [ ] Skill loads full prompt-engineering.mdc on invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `writing-for-llms` skill to load prompt standards on-demand, optimizing context window usage by removing always-on `prompt-engineering.mdc`.
> 
>   - **Behavior**:
>     - Adds `writing-for-llms` skill in `.claude/skills/writing-for-llms/` to load prompt engineering standards on-demand.
>     - Removes `prompt-engineering.mdc` from always-on context, saving ~5.8k tokens per session.
>     - Updates `AGENTS.md` in `lib/prompts/`, `lib/concierge/`, `lib/ai-team/librarian/`, and `evals/` to include skill invocation guidance.
>   - **Files**:
>     - Creates `SKILL.md` in `.claude/skills/writing-for-llms/` with key principles and quality checks for prompt engineering.
>     - Updates `AGENTS.md` in `lib/prompts/` to instruct invoking the skill before editing prompts.
>     - Updates `CLAUDE.md` in `lib/concierge/` to instruct invoking the skill before editing `prompt.ts`.
>   - **Misc**:
>     - Adds `AGENTS.md` in `lib/ai-team/librarian/` and `evals/` with skill reference.
>     - Adds `CLAUDE.md` symlinks in `lib/ai-team/librarian/` and `evals/` pointing to `AGENTS.md`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 85724a6d083a8041162cace1b55576576f679925. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->