### PR TITLE
⚡ Lazy load heavy client-side dependencies

### DIFF
--- a/lib/copy-utils.ts
+++ b/lib/copy-utils.ts
@@ -1,5 +1,14 @@
-import { marked } from "marked";
 import { logger } from "@/lib/client-logger";
+
+/**
+ * Lazy-loaded marked parser for markdown conversion.
+ * Only imported when copyMarkdownWithFormats or copyPlainText is called,
+ * saving ~30KB from the initial bundle.
+ */
+async function getMarked() {
+    const { marked } = await import("marked");
+    return marked;
+}
 
 /**
  * Copy text to clipboard with error handling and structured logging
@@ -36,7 +45,8 @@ export async function copyToClipboard(text: string): Promise<boolean> {
  */
 export async function copyMarkdownWithFormats(markdown: string): Promise<boolean> {
     try {
-        // Convert markdown to HTML
+        // Lazy load marked only when needed
+        const marked = await getMarked();
         const html = await marked(markdown);
 
         // Create clipboard item with multiple formats
@@ -90,7 +100,8 @@ export async function copyMarkdown(markdown: string): Promise<boolean> {
  */
 export async function copyPlainText(markdown: string): Promise<boolean> {
     try {
-        // Convert markdown to HTML first
+        // Lazy load marked only when needed
+        const marked = await getMarked();
         const html = await marked(markdown);
 
         // Create temporary DOM element to extract text

--- a/lib/storage/image-processor.ts
+++ b/lib/storage/image-processor.ts
@@ -8,9 +8,18 @@
  * Uses browser-image-compression to resize images to Claude's sweet spot (1092px).
  */
 
-import imageCompression from "browser-image-compression";
 import { logger } from "@/lib/client-logger";
 import { ALLOWED_MIME_TYPES } from "./file-config";
+
+/**
+ * Lazy-loaded image compression library.
+ * Only imported when optimizeImage is called (user uploads an image),
+ * saving ~15-25KB from the initial bundle.
+ */
+async function getImageCompression() {
+    const { default: imageCompression } = await import("browser-image-compression");
+    return imageCompression;
+}
 
 /**
  * Target dimensions for image optimization.
@@ -67,6 +76,8 @@ export async function optimizeImage(file: File): Promise<File> {
     };
 
     try {
+        // Lazy load compression library only when needed
+        const imageCompression = await getImageCompression();
         const optimizedFile = await imageCompression(file, options);
 
         const endSize = optimizedFile.size;


### PR DESCRIPTION
## Summary

Defer loading of marked, browser-image-compression, and @marker.io/browser until their functionality is actually needed. These libraries are only used on-demand (copy buttons, image uploads, feedback capture) but were loading on every page visit.

**Changes:**
- **marked** (~30KB): Loaded when user clicks copy-with-formats, not on page load
- **browser-image-compression** (~15-25KB): Loaded when user uploads an image
- **@marker.io/browser** (~20-30KB): Loaded when MarkerProvider mounts

**Estimated savings:** 65-105KB from initial bundle.

## Test plan
- [ ] Copy button still works (verify markdown-to-HTML conversion)
- [ ] Image upload still compresses large images
- [ ] Feedback widget still loads and captures screenshots
- [ ] No console errors on first use of each feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Lazy load `marked`, `browser-image-compression`, and `@marker.io/browser` to reduce initial bundle size by 65-105KB.
> 
>   - **Behavior**:
>     - `marked` is lazy-loaded in `copyMarkdownWithFormats()` and `copyPlainText()` in `lib/copy-utils.ts`, reducing initial bundle by ~30KB.
>     - `browser-image-compression` is lazy-loaded in `optimizeImage()` in `lib/storage/image-processor.ts`, reducing initial bundle by ~15-25KB.
>     - `@marker.io/browser` is lazy-loaded in `MarkerProvider` in `components/feedback/marker-provider.tsx`, reducing initial bundle by ~20-30KB.
>   - **Error Handling**:
>     - Adds error handling in `MarkerProvider` to log errors if `@marker.io/browser` fails to load, ensuring graceful degradation.
>   - **Misc**:
>     - Updates comments and docstrings to reflect lazy loading changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 7f885b98aaafa83132be0a61f50c53a4c4ad39c6. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->