### PR TITLE
📱 Fix mobile navigation dead-ends and footer layout

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -212,9 +212,9 @@ function ThemePopover() {
 export function Footer() {
     return (
         <footer className="px-6 py-8 sm:py-10">
-            <div className="mx-auto flex max-w-5xl flex-col gap-8 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mx-auto flex max-w-5xl flex-col gap-6 sm:flex-row sm:items-center sm:justify-between sm:gap-8">
                 {/* Links - grouped for visual hierarchy */}
-                <nav className="text-foreground/60 flex flex-wrap items-center gap-x-8 gap-y-4 text-sm">
+                <nav className="text-foreground/60 flex flex-wrap items-center gap-x-4 gap-y-3 text-xs sm:gap-x-8 sm:gap-y-4 sm:text-sm">
                     {/* Primary links with icons */}
                     <Link
                         href="/heart-centered-ai"
@@ -259,24 +259,24 @@ export function Footer() {
                     >
                         Security
                     </Link>
-
-                    {/* Theme controls */}
-                    <ThemePopover />
                 </nav>
 
-                {/* Credits */}
-                <div className="text-foreground/60 text-sm">
-                    <span>Built with </span>
-                    <Heart className="fill-primary text-primary inline h-3.5 w-3.5" />
-                    <span> by </span>
-                    <Link
-                        href="https://technick.ai"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-foreground/90 transition-all hover:scale-105"
-                    >
-                        technick.ai
-                    </Link>
+                {/* Credits + Theme - grouped on right */}
+                <div className="flex items-center gap-4">
+                    <ThemePopover />
+                    <div className="text-foreground/60 text-xs sm:text-sm">
+                        <span>Built with </span>
+                        <Heart className="fill-primary text-primary inline h-3 w-3 sm:h-3.5 sm:w-3.5" />
+                        <span> by </span>
+                        <Link
+                            href="https://technick.ai"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-foreground/90 transition-all hover:scale-105"
+                        >
+                            technick.ai
+                        </Link>
+                    </div>
                 </div>
             </div>
         </footer>

--- a/components/ui/user-auth-button.tsx
+++ b/components/ui/user-auth-button.tsx
@@ -15,6 +15,7 @@ import {
     Heart,
     Compass,
     Code2,
+    MessageCircle,
 } from "lucide-react";
 
 import { useMarker } from "@/components/feedback/marker-provider";
@@ -244,6 +245,19 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
 
                                   {/* Menu items */}
                                   <div className="py-1">
+                                      {/* Primary action: Back to Chat */}
+                                      <Link
+                                          href="/connection"
+                                          onClick={() => setIsOpen(false)}
+                                          className="group text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium transition-all"
+                                      >
+                                          <div className="bg-primary/10 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
+                                          <MessageCircle className="text-primary relative h-4 w-4" />
+                                          <span className="relative">Connect</span>
+                                      </Link>
+
+                                      <div className="border-foreground/10 my-1 border-t" />
+
                                       {/* Settings & Core Features */}
                                       <button
                                           onClick={() => {


### PR DESCRIPTION
## Summary

- **Add "Connect" link to user dropdown** - Users can now get back to chat after navigating to Knowledge Base, Integrations, or other pages via the avatar menu
- **Improve footer layout on mobile** - Reduce gaps (`gap-x-8` → `gap-x-4`, `gap-y-4` → `gap-y-3`) to prevent awkward wrapping
- **Move ThemePopover** - Relocated from inline with nav links to a grouped section with credits for cleaner mobile layout
- **Scale footer text** - `text-xs` on mobile, `text-sm` on larger screens for better readability

## Issues Fixed

1. **Dead-end navigation**: Users on `/connection` could tap avatar → Knowledge Base → and then had NO way back to their chat
2. **Mangled footer**: Large gaps caused text/icons to wrap awkwardly on narrow screens

## Test Plan

- [x] Type check passes
- [x] ESLint passes  
- [x] All 1,580 unit/integration tests pass
- [x] Logic review: No bugs found
- [x] Style review: Follows codebase conventions
- [ ] Manual: Verify "Connect" appears at top of dropdown menu
- [ ] Manual: Verify footer renders cleanly on 375px viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix mobile navigation dead-ends by adding 'Connect' link to user dropdown and improve footer layout for better mobile appearance.
> 
>   - **Navigation**:
>     - Add 'Connect' link to user dropdown in `UserAuthButton` in `user-auth-button.tsx` to allow users to navigate back to chat from other pages.
>   - **Footer Layout**:
>     - Reduce gaps in footer layout in `footer.tsx` (`gap-x-8` to `gap-x-4`, `gap-y-4` to `gap-y-3`) for better mobile appearance.
>     - Move `ThemePopover` in `footer.tsx` to group with credits for cleaner layout.
>     - Scale footer text in `footer.tsx` to `text-xs` on mobile and `text-sm` on larger screens.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 01407d4584588ac665208f854ed408d499eac54c. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->