### PR TITLE
🐛 Fix iOS Safari cursor positioning by removing Composer transform

### DIFF
--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -274,23 +274,16 @@ function HoloThreadInner() {
             </div>
 
             {/* Input container with safe area for notched devices - glass treatment matches header */}
+            {/* NOTE: No motion.div wrapper here - CSS transforms on iOS Safari cause cursor
+                positioning bugs where the cursor appears displaced from the textarea */}
             <div className="landscape-compact-input border-foreground/5 dark:bg-card/60 flex flex-none items-center justify-center border-t bg-white/60 px-2 pt-1 pb-[max(0.5rem,env(safe-area-inset-bottom))] backdrop-blur-2xl sm:px-4 sm:pt-3 sm:pb-4">
-                <motion.div
-                    className="relative flex w-full flex-col items-center"
-                    initial={{ opacity: 0, y: 40 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{
-                        duration: 0.7,
-                        delay: 0.35,
-                        ease: [0.16, 1, 0.3, 1],
-                    }}
-                >
+                <div className="relative flex w-full flex-col items-center">
                     <ScrollToBottomButton
                         isAtBottom={isAtBottom}
                         onScrollToBottom={() => scrollToBottom("smooth")}
                     />
                     <Composer onMarkMessageStopped={handleMarkMessageStopped} />
-                </motion.div>
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- Remove `motion.div` wrapper from Composer that was applying CSS transforms
- iOS Safari miscalculates cursor position when parent elements have transforms
- Follow-up to #551 which addressed a different cursor issue (JS height manipulation)

## Root Cause
Framer Motion was applying `translateY` transforms for an entrance animation on the Composer wrapper. Even after animation completes, it leaves `transform: translateY(0px)` on the element. iOS Safari doesn't properly account for this when calculating cursor rendering position, causing the cursor to appear displaced from where the user tapped.

## Trade-off
We lose a subtle fade+slide entrance animation on the composer. The cursor bug fix is worth this minor visual polish loss.

## Test Plan
- [x] Build passes
- [x] All unit/integration tests pass
- [ ] **Manual iOS Safari testing required**: Open a conversation, tap elsewhere to blur textarea, tap back on textarea to refocus, verify cursor appears at correct position

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `motion.div` wrapper in `holo-thread.tsx` to fix iOS Safari cursor positioning issue, losing entrance animation.
> 
>   - **Behavior**:
>     - Remove `motion.div` wrapper from input container in `holo-thread.tsx` to fix iOS Safari cursor positioning issue.
>     - Fixes cursor displacement caused by `transform: translateY(0px)` left by Framer Motion.
>   - **Trade-off**:
>     - Loss of fade+slide entrance animation on the composer.
>   - **Testing**:
>     - Manual iOS Safari testing required to verify cursor position when refocusing textarea.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=carmentacollective%2Fcarmenta&utm_source=github&utm_medium=referral)<sup> for 64e1524ac5d812cb53349f4a9b73b67dcc31017c. You can [customize](https://app.ellipsis.dev/carmentacollective/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->