### PR TITLE
🐛 Fix Temporal worker DNS resolution and make background mode explicit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -125,11 +125,10 @@ CLERK_SECRET_KEY=
 #   - SET:         Background mode enabled, connects to the specified address
 #
 # Examples:
-#   TEMPORAL_ADDRESS=localhost:7233                    # Local Docker (pnpm dev:temporal)
-#   TEMPORAL_ADDRESS=temporal-server.internal:7233    # Self-hosted on Render/AWS/etc
-#   TEMPORAL_ADDRESS=your-ns.tmprl.cloud:7233         # Temporal Cloud
+#   TEMPORAL_ADDRESS=localhost:7233                  # Local Docker (pnpm dev:temporal)
+#   TEMPORAL_ADDRESS=carmenta-temporal-server:7233  # Render private service
+#   TEMPORAL_ADDRESS=your-ns.tmprl.cloud:7233       # Temporal Cloud
 #
-# If Temporal is configured but unavailable, requests gracefully fall back to inline.
 # TEMPORAL_ADDRESS=localhost:7233
 
 # =============================================================================

--- a/app/api/connection/route.ts
+++ b/app/api/connection/route.ts
@@ -58,7 +58,10 @@ import { triggerLibrarian } from "@/lib/ai-team/librarian/trigger";
 import { type DiscoveryItem } from "@/lib/discovery";
 import { writeStatus, STATUS_MESSAGES } from "@/lib/streaming";
 import { getStreamContext } from "@/lib/streaming/stream-context";
-import { startBackgroundResponse } from "@/lib/temporal/client";
+import {
+    isBackgroundModeEnabled,
+    startBackgroundResponse,
+} from "@/lib/temporal/client";
 
 /**
  * Route segment config for Vercel
@@ -302,7 +305,7 @@ export async function POST(req: Request) {
         // close, deploys, and connection drops.
         //
         // Gracefully disabled if Temporal isn't configured - runs inline instead.
-        const temporalConfigured = !!process.env.TEMPORAL_ADDRESS;
+        const temporalConfigured = isBackgroundModeEnabled();
         if (conciergeResult.backgroundMode?.enabled && !temporalConfigured) {
             logger.info(
                 { connectionId, reason: conciergeResult.backgroundMode.reason },

--- a/render.yaml
+++ b/render.yaml
@@ -41,11 +41,10 @@ services:
           type: redis
           property: connectionString
       # TEMPORAL_ADDRESS controls background mode availability:
-      # - Remove this to disable background mode (requests run inline)
-      # - Set to your Temporal server to enable durable background execution
-      # Falls back to inline gracefully if Temporal is unavailable
+      # - Unset/remove to disable background mode (requests run inline)
+      # - Set to Temporal server address to enable durable background execution
       - key: TEMPORAL_ADDRESS
-        value: carmenta-temporal-server.internal:7233
+        value: carmenta-temporal-server:7233
 
   # Redis for resumable streams and caching
   - type: redis
@@ -57,7 +56,7 @@ services:
 
   # Temporal Server - workflow orchestration engine
   # Uses temporalio/auto-setup for automatic schema creation
-  # Private service - accessible via carmenta-temporal-server.internal:7233
+  # Private service - accessible via carmenta-temporal-server:7233
   - type: pserv
     name: carmenta-temporal-server
     runtime: docker
@@ -66,6 +65,8 @@ services:
     dockerfilePath: ./docker/temporal-server/Dockerfile
     autoDeploy: true
     envVars:
+      - key: BIND_ON_IP
+        value: "0.0.0.0" # Listen on all interfaces (required for private network access)
       - key: DB
         value: postgres12 # Temporal's driver name for PostgreSQL 12+
       - key: DB_PORT
@@ -98,7 +99,7 @@ services:
       - key: NODE_ENV
         value: production
       - key: TEMPORAL_ADDRESS
-        value: carmenta-temporal-server.internal:7233
+        value: carmenta-temporal-server:7233
       - key: DATABASE_URL
         fromDatabase:
           name: carmenta-db


### PR DESCRIPTION
## Summary

- Fix Temporal worker DNS resolution failure on Render by correcting hostname format and server binding
- Make background mode explicitly opt-in via `TEMPORAL_ADDRESS` environment variable
- Add proper error handling and Sentry capture for misconfiguration

## Problem

The Temporal worker was crash-looping on Render with DNS resolution errors:
```
TransportError: dns error - failed to lookup address information: Name or service not known
```

Two root causes:
1. **Wrong hostname format**: Used `.internal` suffix which doesn't exist on Render
2. **Server binding**: Temporal server was binding to localhost only, not accessible from private network

## Solution

### render.yaml
- Add `BIND_ON_IP=0.0.0.0` to Temporal server (listen on all interfaces)
- Fix hostname from `carmenta-temporal-server.internal:7233` to `carmenta-temporal-server:7233`

### lib/temporal/client.ts
- Add `isBackgroundModeEnabled()` function for explicit opt-in check
- Make `getTemporalClient()` throw if `TEMPORAL_ADDRESS` not set (no silent fallback)

### worker/index.ts
- Exit cleanly with clear error message if `TEMPORAL_ADDRESS` not set
- Add Sentry capture so misconfiguration is visible in monitoring

### app/api/connection/route.ts
- Use `isBackgroundModeEnabled()` for consistency across codebase

## Behavior After This PR

| Configuration | Behavior |
|--------------|----------|
| `TEMPORAL_ADDRESS` not set | Background mode disabled, requests run inline |
| `TEMPORAL_ADDRESS` set | Background mode enabled, connects to Temporal |
| Worker without `TEMPORAL_ADDRESS` | Clean exit with error message (not crash-loop) |

## Test plan

- [x] Type check passes
- [x] Lint passes
- [x] All 1630 tests pass
- [ ] Deploy to Render and verify worker connects to Temporal server
- [ ] Test background mode request flows through successfully

Generated with Carmenta