### PR TITLE
🐛 Fix duplicate repos in Code Mode and add Sentry environment support

### DIFF
--- a/lib/code/projects.ts
+++ b/lib/code/projects.ts
@@ -79,11 +79,15 @@ function isSafeSourceDir(dir: string): boolean {
  * Default source directories to scan for projects
  */
 const DEFAULT_SOURCE_DIRS = [
-    process.env.CODE_SOURCE_DIR,
-    process.env.HOME ? path.join(process.env.HOME, "src") : null,
-]
-    .filter((dir): dir is string => Boolean(dir))
-    .filter(isSafeSourceDir);
+    ...new Set(
+        [
+            process.env.CODE_SOURCE_DIR,
+            process.env.HOME ? path.join(process.env.HOME, "src") : null,
+        ]
+            .filter((dir): dir is string => Boolean(dir))
+            .map((dir) => path.resolve(dir)) // Normalize paths for deduplication
+    ),
+].filter(isSafeSourceDir);
 
 /**
  * Maximum depth to recurse when looking for git repos

--- a/sentry.client.config.ts
+++ b/sentry.client.config.ts
@@ -19,8 +19,8 @@ Sentry.init({
     // Only send errors in production
     enabled: process.env.NODE_ENV === "production",
 
-    // Set environment
-    environment: process.env.NODE_ENV,
+    // Set environment - use SENTRY_ENVIRONMENT for deployment distinction
+    environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT || process.env.NODE_ENV,
 
     // Don't log debug info in production
     debug: false,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -15,8 +15,8 @@ Sentry.init({
     // Only send errors in production
     enabled: process.env.NODE_ENV === "production",
 
-    // Set environment
-    environment: process.env.NODE_ENV,
+    // Set environment - use SENTRY_ENVIRONMENT for deployment distinction
+    environment: process.env.SENTRY_ENVIRONMENT || process.env.NODE_ENV,
 
     // Don't log debug info in production
     debug: false,


### PR DESCRIPTION
## Summary
- Deduplicate `DEFAULT_SOURCE_DIRS` to prevent scanning same directory twice when `CODE_SOURCE_DIR` and `$HOME/src` resolve to the same path
- Add `SENTRY_ENVIRONMENT` / `NEXT_PUBLIC_SENTRY_ENVIRONMENT` support for distinguishing between deployments (e.g., `technickai-godmode` vs `production`)

## Test plan
- [x] All 1764 tests pass
- [x] Verified on technickai.carmenta.ai - repos now show once instead of twice

Generated with Carmenta