### PR TITLE
🐛 Fix path traversal check for root directory "/"

### DIFF
--- a/app/api/code/[repo]/files/content/route.ts
+++ b/app/api/code/[repo]/files/content/route.ts
@@ -150,7 +150,9 @@ export async function GET(
             });
         }
 
-        const absolutePath = path.resolve(project.path, filePath);
+        // Normalize path for actual file operations (same as security check)
+        const safePath = filePath.replace(/^\/+/, "") || ".";
+        const absolutePath = path.resolve(project.path, safePath);
 
         // Check file exists
         let stat;

--- a/app/api/code/[repo]/files/route.ts
+++ b/app/api/code/[repo]/files/route.ts
@@ -159,7 +159,9 @@ export async function GET(
             });
         }
 
-        const absolutePath = path.resolve(project.path, relativePath);
+        // Normalize path for actual file operations (same as security check)
+        const safePath = relativePath.replace(/^\/+/, "") || ".";
+        const absolutePath = path.resolve(project.path, safePath);
 
         // Check path exists and is a directory
         let stat;


### PR DESCRIPTION
## Summary
- `path.resolve()` treats "/" as absolute, returning "/" instead of the project root
- Strip leading slashes to ensure relative path resolution
- Fixes "Failed to load root directory" error in Code Mode file browser

## Test plan
- [x] All 1769 tests pass
- [x] Verified file browser loads root directory in Code Mode

Generated with Carmenta