### PR TITLE
✨ Add clarifying questions before deep research + eager mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,6 +133,12 @@ CLERK_SECRET_KEY=
 #
 # TEMPORAL_ADDRESS=localhost:7233
 
+# Eager mode - Run background tasks inline without Temporal (like Celery's ALWAYS_EAGER)
+# For development only. Tasks run in the same process - no durability, no recovery.
+# Set this when you want to test background mode UX without running Temporal.
+#
+# BACKGROUND_MODE_EAGER=true
+
 # =============================================================================
 # SECURITY
 # =============================================================================

--- a/lib/concierge/types.ts
+++ b/lib/concierge/types.ts
@@ -204,6 +204,22 @@ export interface KBSearchConfig {
 }
 
 /**
+ * A clarifying question the concierge wants to ask before proceeding.
+ * Used to scope deep research or resolve ambiguity.
+ */
+export interface ClarifyingQuestion {
+    /** The question to ask the user */
+    question: string;
+    /** Predefined options for quick selection */
+    options: Array<{
+        label: string;
+        value: string;
+    }>;
+    /** Whether to allow free-form text input alongside options */
+    allowFreeform?: boolean;
+}
+
+/**
  * Result returned by the Concierge after analyzing a request.
  */
 export interface ConciergeResult {
@@ -271,7 +287,7 @@ export interface ConciergeResult {
     /**
      * Background mode configuration.
      *
-     * When enabled, the response runs via Inngest for durable execution.
+     * When enabled, the response runs via Temporal for durable execution.
      * This allows long-running work to survive browser close, deploys,
      * and connection drops. The user sees "still working" status.
      */
@@ -281,6 +297,19 @@ export interface ConciergeResult {
         /** Reason shown to user (e.g., "Deep research - this will take a few minutes") */
         reason?: string;
     };
+
+    /**
+     * Clarifying questions to ask before proceeding.
+     *
+     * When the concierge detects a deep research request or ambiguity,
+     * it can ask scoping questions before starting work. This helps
+     * ensure the response matches user intent.
+     *
+     * When set, the route should return these questions to the user
+     * instead of starting LLM generation. The user's answers get
+     * appended to the conversation, and a new request is made.
+     */
+    clarifyingQuestions?: ClarifyingQuestion[];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Before starting deep research, the concierge now asks scoping questions to ensure we deliver what the user needs
- Surfaces Parallel.ai's research depth options as user choices
- Adds `BACKGROUND_MODE_EAGER` for dev - runs Temporal workflow logic inline without infrastructure

## Research Depth Options

When the concierge detects a research task, users can now choose:
- **Quick answer** - No research, just answer from what I know
- **Quick research** (~20 seconds) - Light search and synthesis
- **Standard research** (~1 minute) - Thorough investigation
- **Deep research** (~2 minutes) - Runs in background, comprehensive multi-source analysis

## Eager Mode

Like Celery's `ALWAYS_EAGER` - set `BACKGROUND_MODE_EAGER=true` to run background tasks inline during development without Temporal infrastructure.

## Changes

- `lib/concierge/types.ts` - Add `ClarifyingQuestion` and `clarifyingQuestions` to `ConciergeResult`
- `lib/concierge/index.ts` - Update schema and processing for clarifying questions
- `lib/concierge/prompt.ts` - Add examples for research depth scoping
- `lib/temporal/client.ts` - Add `isEagerMode()` and eager execution path
- `app/api/connection/route.ts` - Handle clarifying questions, return `data-clarifying-question` parts
- `.env.example` - Document `BACKGROUND_MODE_EAGER`

## What's Not Done

Client-side rendering of clarifying questions is not yet implemented. The server sends `data-clarifying-question` parts but they won't render until client handling is added. This PR sets up the infrastructure.

## Test plan

- [ ] Set `BACKGROUND_MODE_EAGER=true` in `.env.local`
- [ ] Send a research query like "research healthy restaurants in Austin"
- [ ] Check logs for `clarifyingQuestions` in concierge output
- [ ] Verify eager mode logs show "Starting background response in eager mode"

Generated with Carmenta