### PR TITLE
🐛 Fix drizzle-kit not loading .env.local

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -6,18 +6,18 @@
  * Run `pnpm run db:migrate` to apply migrations.
  */
 
-import type { Config } from "drizzle-kit";
+import { config } from "dotenv";
+import { defineConfig } from "drizzle-kit";
 
-export default {
+config({ path: ".env.local" });
+
+export default defineConfig({
     schema: "./lib/db/schema.ts",
     out: "./drizzle/migrations",
     dialect: "postgresql",
     dbCredentials: {
-        // DATABASE_URL from Render, fall back to localhost for development
-        url: process.env.DATABASE_URL ?? "postgresql://localhost:5432/carmenta",
+        url: process.env.DATABASE_URL!,
     },
-    // Verbose output for debugging
     verbose: true,
-    // Strict mode for safer migrations
     strict: true,
-} satisfies Config;
+});


### PR DESCRIPTION
## Summary
- Use dotenv to explicitly load `.env.local` in `drizzle.config.ts`
- Follows Drizzle's official best practice for Next.js projects

## Problem
Drizzle-kit is a standalone CLI that doesn't automatically load Next.js env files. The config was falling back to `localhost:5432` because `process.env.DATABASE_URL` was undefined.

## Test plan
- [x] Verified `pnpm db:generate` now shows "injecting env from .env.local"
- [ ] Run `pnpm db:migrate` to confirm it connects to RDS

Generated with Carmenta