### PR TITLE
🐛 Fix trailing slash bug in Temporal workflow URL generation

### DIFF
--- a/__tests__/unit/lib/observability/external-links.test.ts
+++ b/__tests__/unit/lib/observability/external-links.test.ts
@@ -147,10 +147,21 @@ describe("External Links", () => {
 
             const url = getTemporalWorkflowUrl("wf123");
 
-            // Note: Current implementation doesn't strip trailing slash
-            // This is the actual behavior we're documenting
+            // Implementation strips trailing slashes to avoid double slashes
             expect(url).toBe(
-                "https://temporal.example.com//namespaces/dev/workflows/wf123"
+                "https://temporal.example.com/namespaces/dev/workflows/wf123"
+            );
+        });
+
+        it("handles base URL with multiple trailing slashes", () => {
+            process.env.TEMPORAL_UI_URL = "https://temporal.example.com///";
+            process.env.TEMPORAL_NAMESPACE = "dev";
+
+            const url = getTemporalWorkflowUrl("wf123");
+
+            // Implementation strips all trailing slashes
+            expect(url).toBe(
+                "https://temporal.example.com/namespaces/dev/workflows/wf123"
             );
         });
 

--- a/lib/observability/external-links.ts
+++ b/lib/observability/external-links.ts
@@ -27,8 +27,11 @@ export function getTemporalWorkflowUrl(workflowId: string): string | null {
 
     if (!baseUrl) return null;
 
+    // Strip trailing slashes to avoid double slashes in the URL
+    const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
+
     const namespace = process.env.TEMPORAL_NAMESPACE || "default";
-    return `${baseUrl}/namespaces/${encodeURIComponent(namespace)}/workflows/${encodeURIComponent(workflowId)}`;
+    return `${normalizedBaseUrl}/namespaces/${encodeURIComponent(namespace)}/workflows/${encodeURIComponent(workflowId)}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
Addresses code review feedback from PR #599:
- Strip trailing slashes from `TEMPORAL_UI_URL` to avoid double slashes in generated URLs
- Update test to expect correct behavior instead of documenting the bug
- Add test case for multiple trailing slashes

## Issue
Claude bot caught this during code review of #599. The test documented broken behavior:
```typescript
expect(url).toBe("https://temporal.example.com//namespaces/dev/workflows/wf123");
//                                           ^^^ double slash
```

This is a real production bug - Temporal URLs with double slashes may not work correctly.

## Fix
```typescript
// Strip trailing slashes to avoid double slashes in the URL
const normalizedBaseUrl = baseUrl.replace(/\/+$/, "");
```

## Test plan
- [x] Updated test expects single slash (correct behavior)
- [x] Added test for multiple trailing slashes
- [x] All 26 external-links tests pass
- [x] Full test suite passes (1861 tests)

Generated with Carmenta