### PR TITLE
✨ Add Spotify integration

### DIFF
--- a/__tests__/unit/lib/integrations/adapters/spotify.test.ts
+++ b/__tests__/unit/lib/integrations/adapters/spotify.test.ts
@@ -1,0 +1,632 @@
+/**
+ * Spotify Adapter Tests
+ *
+ * Tests authentication and core operations for the Spotify adapter.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { SpotifyAdapter } from "@/lib/integrations/adapters/spotify";
+import { ValidationError } from "@/lib/errors";
+
+// Mock connection manager
+vi.mock("@/lib/integrations/connection-manager", () => ({
+    getCredentials: vi.fn(),
+}));
+
+// Mock HTTP client
+vi.mock("@/lib/http-client", () => ({
+    httpClient: {
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+// Mock env
+vi.mock("@/lib/env", () => ({
+    env: {
+        NEXT_PUBLIC_APP_URL: "https://carmenta.ai",
+        SPOTIFY_CLIENT_ID: "test-client-id",
+        SPOTIFY_CLIENT_SECRET: "test-client-secret",
+    },
+}));
+
+describe("SpotifyAdapter", () => {
+    let adapter: SpotifyAdapter;
+    const testUserEmail = "test@example.com";
+
+    beforeEach(() => {
+        adapter = new SpotifyAdapter();
+        vi.clearAllMocks();
+    });
+
+    describe("Authentication", () => {
+        it("returns friendly error when service not connected", async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockRejectedValue(
+                new ValidationError("spotify is not connected")
+            );
+
+            const result = await adapter.execute(
+                "search",
+                { query: "test" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("spotify");
+        });
+
+        it("proceeds with valid OAuth credentials", async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    tracks: {
+                        items: [
+                            {
+                                id: "track-123",
+                                name: "Test Song",
+                                artists: [{ name: "Test Artist" }],
+                                album: { name: "Test Album" },
+                                duration_ms: 180000,
+                                uri: "spotify:track:track-123",
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/track/track-123",
+                                },
+                            },
+                        ],
+                    },
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "search",
+                { query: "test song" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            expect(getCredentials).toHaveBeenCalledWith(
+                testUserEmail,
+                "spotify",
+                undefined
+            );
+        });
+    });
+
+    describe("Search Operation", () => {
+        beforeEach(async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+        });
+
+        it("searches for tracks", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    tracks: {
+                        items: [
+                            {
+                                id: "track-123",
+                                name: "Bohemian Rhapsody",
+                                artists: [{ name: "Queen" }],
+                                album: { name: "A Night at the Opera" },
+                                duration_ms: 354000,
+                                uri: "spotify:track:track-123",
+                                external_urls: {
+                                    spotify: "https://open.spotify.com/track/track-123",
+                                },
+                            },
+                        ],
+                    },
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "search",
+                { query: "Bohemian Rhapsody", type: "track" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.tracks).toHaveLength(1);
+            expect(content.tracks[0].name).toBe("Bohemian Rhapsody");
+            expect(content.tracks[0].artists).toBe("Queen");
+        });
+
+        it("searches for playlists", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    playlists: {
+                        items: [
+                            {
+                                id: "playlist-123",
+                                name: "Focus Music",
+                                description: "Music for concentration",
+                                owner: { id: "spotify", display_name: "Spotify" },
+                                public: true,
+                                tracks: { total: 50 },
+                                uri: "spotify:playlist:playlist-123",
+                                external_urls: {
+                                    spotify:
+                                        "https://open.spotify.com/playlist/playlist-123",
+                                },
+                            },
+                        ],
+                    },
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "search",
+                { query: "focus music", type: "playlist" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.playlists).toHaveLength(1);
+            expect(content.playlists[0].name).toBe("Focus Music");
+        });
+    });
+
+    describe("Currently Playing", () => {
+        beforeEach(async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+        });
+
+        it("returns currently playing track", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    is_playing: true,
+                    progress_ms: 60000,
+                    item: {
+                        id: "track-123",
+                        name: "Test Song",
+                        artists: [{ name: "Test Artist" }],
+                        album: { name: "Test Album" },
+                        duration_ms: 180000,
+                        uri: "spotify:track:track-123",
+                        external_urls: {
+                            spotify: "https://open.spotify.com/track/track-123",
+                        },
+                    },
+                    device: {
+                        name: "My Computer",
+                        type: "Computer",
+                        volume_percent: 50,
+                    },
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "get_currently_playing",
+                {},
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.isPlaying).toBe(true);
+            expect(content.track.name).toBe("Test Song");
+            expect(content.progressFormatted).toBe("1:00");
+        });
+
+        it("handles no active playback gracefully", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockRejectedValue(new Error("204")),
+            } as never);
+
+            const result = await adapter.execute(
+                "get_currently_playing",
+                {},
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.isPlaying).toBe(false);
+            expect(content.message).toContain("No active playback");
+        });
+    });
+
+    describe("Playback Control", () => {
+        beforeEach(async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+        });
+
+        it("starts playback", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.put as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({}),
+            } as never);
+
+            const result = await adapter.execute(
+                "play",
+                { uri: "spotify:track:track-123" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            expect(result.content[0].text).toContain("Started playing");
+            expect(httpClient.put).toHaveBeenCalled();
+        });
+
+        it("pauses playback", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.put as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({}),
+            } as never);
+
+            const result = await adapter.execute("pause", {}, testUserEmail);
+
+            expect(result.isError).toBe(false);
+            expect(result.content[0].text).toContain("Paused");
+        });
+
+        it("handles Premium required error", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            // PUT for play returns a thenable that rejects, not an object with .json()
+            (httpClient.put as Mock).mockRejectedValue(
+                new Error("HTTP 403: Forbidden")
+            );
+
+            const result = await adapter.execute("play", {}, testUserEmail);
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("Premium required");
+        });
+
+        it("handles no active device error", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            // PUT for play returns a thenable that rejects, not an object with .json()
+            (httpClient.put as Mock).mockRejectedValue(
+                new Error("HTTP 404: Not Found")
+            );
+
+            const result = await adapter.execute("play", {}, testUserEmail);
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("No active Spotify device");
+        });
+    });
+
+    describe("Top Items", () => {
+        beforeEach(async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+        });
+
+        it("gets top artists", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    items: [
+                        {
+                            id: "artist-123",
+                            name: "Test Artist",
+                            genres: ["rock", "alternative"],
+                            followers: { total: 1000000 },
+                            popularity: 85,
+                            uri: "spotify:artist:artist-123",
+                            external_urls: {
+                                spotify: "https://open.spotify.com/artist/artist-123",
+                            },
+                        },
+                    ],
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "get_top_items",
+                { type: "artists", time_range: "short_term" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.type).toBe("artists");
+            expect(content.timeRange).toBe("last 4 weeks");
+            expect(content.artists[0].name).toBe("Test Artist");
+        });
+
+        it("gets top tracks", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    items: [
+                        {
+                            id: "track-123",
+                            name: "Top Song",
+                            artists: [{ name: "Popular Artist" }],
+                            album: { name: "Hit Album" },
+                            duration_ms: 200000,
+                            uri: "spotify:track:track-123",
+                            external_urls: {
+                                spotify: "https://open.spotify.com/track/track-123",
+                            },
+                        },
+                    ],
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "get_top_items",
+                { type: "tracks", time_range: "long_term" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.type).toBe("tracks");
+            expect(content.timeRange).toBe("all time");
+            expect(content.tracks[0].name).toBe("Top Song");
+        });
+    });
+
+    describe("Playlists", () => {
+        beforeEach(async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+        });
+
+        it("lists user playlists", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    items: [
+                        {
+                            id: "playlist-123",
+                            name: "My Playlist",
+                            description: "A test playlist",
+                            owner: { id: "user123", display_name: "Test User" },
+                            public: true,
+                            tracks: { total: 25 },
+                            uri: "spotify:playlist:playlist-123",
+                            external_urls: {
+                                spotify:
+                                    "https://open.spotify.com/playlist/playlist-123",
+                            },
+                        },
+                    ],
+                    total: 10,
+                }),
+            } as never);
+
+            const result = await adapter.execute("list_playlists", {}, testUserEmail);
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.totalCount).toBe(10);
+            expect(content.playlists[0].name).toBe("My Playlist");
+        });
+
+        it("gets playlist details with tracks", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockResolvedValue({
+                    id: "playlist-123",
+                    name: "My Playlist",
+                    description: "A test playlist",
+                    owner: { id: "user123", display_name: "Test User" },
+                    public: true,
+                    collaborative: false,
+                    uri: "spotify:playlist:playlist-123",
+                    external_urls: {
+                        spotify: "https://open.spotify.com/playlist/playlist-123",
+                    },
+                    tracks: {
+                        total: 2,
+                        items: [
+                            {
+                                track: {
+                                    id: "track-1",
+                                    name: "Song One",
+                                    artists: [{ name: "Artist One" }],
+                                    album: { name: "Album One" },
+                                    duration_ms: 180000,
+                                    uri: "spotify:track:track-1",
+                                    external_urls: {
+                                        spotify:
+                                            "https://open.spotify.com/track/track-1",
+                                    },
+                                },
+                                added_at: "2024-01-01T00:00:00Z",
+                            },
+                            {
+                                track: {
+                                    id: "track-2",
+                                    name: "Song Two",
+                                    artists: [{ name: "Artist Two" }],
+                                    album: { name: "Album Two" },
+                                    duration_ms: 240000,
+                                    uri: "spotify:track:track-2",
+                                    external_urls: {
+                                        spotify:
+                                            "https://open.spotify.com/track/track-2",
+                                    },
+                                },
+                                added_at: "2024-01-02T00:00:00Z",
+                            },
+                        ],
+                    },
+                }),
+            } as never);
+
+            const result = await adapter.execute(
+                "get_playlist",
+                { playlist_id: "playlist-123" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(false);
+            const content = JSON.parse(result.content[0].text as string);
+            expect(content.name).toBe("My Playlist");
+            expect(content.totalTracks).toBe(2);
+            expect(content.tracks).toHaveLength(2);
+        });
+    });
+
+    describe("Validation", () => {
+        it("requires query for search", async () => {
+            const result = await adapter.execute("search", {}, testUserEmail);
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("query");
+        });
+
+        it("requires type for get_top_items", async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+
+            const result = await adapter.execute("get_top_items", {}, testUserEmail);
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("type");
+        });
+
+        it("requires playlist_id for get_playlist", async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+
+            const result = await adapter.execute("get_playlist", {}, testUserEmail);
+
+            expect(result.isError).toBe(true);
+            expect(result.content[0].text).toContain("playlist_id");
+        });
+    });
+
+    describe("Error Handling", () => {
+        beforeEach(async () => {
+            const { getCredentials } =
+                await import("@/lib/integrations/connection-manager");
+            (getCredentials as Mock).mockResolvedValue({
+                type: "oauth",
+                accessToken: "test-access-token",
+                accountId: "test@spotify.com",
+                accountDisplayName: "Test User",
+                isDefault: true,
+            });
+        });
+
+        it("handles 401 authentication errors", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi.fn().mockRejectedValue(new Error("HTTP 401: Unauthorized")),
+            } as never);
+
+            const result = await adapter.execute(
+                "search",
+                { query: "test" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(true);
+        });
+
+        it("handles 429 rate limit errors", async () => {
+            const { httpClient } = await import("@/lib/http-client");
+            (httpClient.get as Mock).mockReturnValue({
+                json: vi
+                    .fn()
+                    .mockRejectedValue(new Error("HTTP 429: Too Many Requests")),
+            } as never);
+
+            const result = await adapter.execute(
+                "search",
+                { query: "test" },
+                testUserEmail
+            );
+
+            expect(result.isError).toBe(true);
+        });
+    });
+
+    describe("Help Documentation", () => {
+        it("returns help documentation", () => {
+            const help = adapter.getHelp();
+
+            expect(help.service).toBe("Spotify");
+            expect(help.operations).toHaveLength(12); // 11 core + raw_api
+            expect(help.commonOperations).toContain("search");
+            expect(help.commonOperations).toContain("get_currently_playing");
+        });
+
+        it("documents all required parameters", () => {
+            const help = adapter.getHelp();
+            const searchOp = help.operations.find((op) => op.name === "search");
+
+            expect(searchOp).toBeDefined();
+            expect(searchOp?.parameters.find((p) => p.name === "query")?.required).toBe(
+                true
+            );
+        });
+    });
+});

--- a/__tests__/unit/lib/integrations/oauth/providers.test.ts
+++ b/__tests__/unit/lib/integrations/oauth/providers.test.ts
@@ -79,14 +79,15 @@ describe("OAuth Provider Registry", () => {
         it("returns only currently registered providers", () => {
             const ids = getOAuthProviderIds();
 
-            // All 7 OAuth providers are now registered
-            expect(ids).toHaveLength(7);
+            // All 8 OAuth providers are now registered
+            expect(ids).toHaveLength(8);
             expect(ids).toContain("notion");
             expect(ids).toContain("slack");
             expect(ids).toContain("clickup");
             expect(ids).toContain("dropbox");
             expect(ids).toContain("gmail");
             expect(ids).toContain("google-calendar-contacts");
+            expect(ids).toContain("spotify");
             expect(ids).toContain("twitter");
         });
     });

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -54,6 +54,9 @@ export const env = createEnv({
         // In-house OAuth credentials - Google Restricted (Gmail)
         GOOGLE_RESTRICTED_CLIENT_ID: z.string().min(1).optional(),
         GOOGLE_RESTRICTED_CLIENT_SECRET: z.string().min(1).optional(),
+        // In-house OAuth credentials - Spotify
+        SPOTIFY_CLIENT_ID: z.string().min(1).optional(),
+        SPOTIFY_CLIENT_SECRET: z.string().min(1).optional(),
         // In-house OAuth credentials - Twitter/X
         TWITTER_CLIENT_ID: z.string().min(1).optional(),
         TWITTER_CLIENT_SECRET: z.string().min(1).optional(),
@@ -114,6 +117,8 @@ export const env = createEnv({
         GOOGLE_SENSITIVE_CLIENT_SECRET: process.env.GOOGLE_SENSITIVE_CLIENT_SECRET,
         GOOGLE_RESTRICTED_CLIENT_ID: process.env.GOOGLE_RESTRICTED_CLIENT_ID,
         GOOGLE_RESTRICTED_CLIENT_SECRET: process.env.GOOGLE_RESTRICTED_CLIENT_SECRET,
+        SPOTIFY_CLIENT_ID: process.env.SPOTIFY_CLIENT_ID,
+        SPOTIFY_CLIENT_SECRET: process.env.SPOTIFY_CLIENT_SECRET,
         TWITTER_CLIENT_ID: process.env.TWITTER_CLIENT_ID,
         TWITTER_CLIENT_SECRET: process.env.TWITTER_CLIENT_SECRET,
         BRAINTRUST_API_KEY: process.env.BRAINTRUST_API_KEY,

--- a/lib/integrations/adapters/index.ts
+++ b/lib/integrations/adapters/index.ts
@@ -30,4 +30,5 @@ export { LimitlessAdapter } from "./limitless";
 export { NotionAdapter } from "./notion";
 export { QuoAdapter } from "./quo";
 export { SlackAdapter } from "./slack";
+export { SpotifyAdapter } from "./spotify";
 export { TwitterAdapter } from "./twitter";

--- a/lib/integrations/adapters/spotify.ts
+++ b/lib/integrations/adapters/spotify.ts
@@ -1,0 +1,1087 @@
+/**
+ * Spotify Service Adapter
+ *
+ * Music streaming via Spotify API using in-house OAuth.
+ *
+ * ## Use Cases
+ * - Music discovery: Search for tracks, albums, artists, playlists
+ * - What's playing: Get currently playing track, playback state
+ * - Playback control: Play, pause, skip (requires Premium)
+ * - Listening insights: Top artists/tracks, recently played
+ * - Playlist management: List playlists, get playlist details
+ *
+ * ## Premium vs Free
+ * Playback control (play, pause, next, previous) requires Spotify Premium.
+ * Free users will get a 403 error on these operations.
+ */
+
+import { ServiceAdapter, HelpResponse, MCPToolResponse, RawAPIParams } from "./base";
+import { httpClient } from "@/lib/http-client";
+import { logger } from "@/lib/logger";
+import { SPOTIFY_API_BASE } from "../oauth/providers/spotify";
+
+export class SpotifyAdapter extends ServiceAdapter {
+    serviceName = "spotify";
+    serviceDisplayName = "Spotify";
+
+    /**
+     * Build headers for Spotify API requests.
+     * Spotify uses Bearer token authentication.
+     */
+    private buildHeaders(accessToken: string): Record<string, string> {
+        return {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+        };
+    }
+
+    /**
+     * Test the OAuth connection by making a live API request.
+     * Called when user clicks "Test" button to verify credentials are working.
+     */
+    async testConnection(
+        credentialOrToken: string,
+        userId?: string
+    ): Promise<{ success: boolean; error?: string }> {
+        try {
+            await httpClient
+                .get(`${SPOTIFY_API_BASE}/me`, {
+                    headers: this.buildHeaders(credentialOrToken),
+                })
+                .json<Record<string, unknown>>();
+
+            return { success: true };
+        } catch (error) {
+            logger.error({ error, userId }, "Failed to verify Spotify connection");
+            return {
+                success: false,
+                error:
+                    error instanceof Error
+                        ? error.message
+                        : "Connection verification failed",
+            };
+        }
+    }
+
+    getHelp(): HelpResponse {
+        return {
+            service: this.serviceDisplayName,
+            description:
+                "Music streaming and discovery. Playback control requires Spotify Premium.",
+            commonOperations: ["search", "get_currently_playing", "list_playlists"],
+            operations: [
+                {
+                    name: "search",
+                    description:
+                        "Search for tracks, albums, artists, playlists, shows, or episodes",
+                    parameters: [
+                        {
+                            name: "query",
+                            type: "string",
+                            required: true,
+                            description:
+                                "Search query (e.g., 'Bohemian Rhapsody', 'artist:Queen', 'genre:rock')",
+                            example: "Bohemian Rhapsody",
+                        },
+                        {
+                            name: "type",
+                            type: "string",
+                            required: false,
+                            description:
+                                "Type(s) to search for: track, album, artist, playlist, show, episode. Comma-separated for multiple.",
+                            example: "track,artist",
+                        },
+                        {
+                            name: "limit",
+                            type: "number",
+                            required: false,
+                            description: "Max results to return (1-50, default: 20)",
+                            example: "10",
+                        },
+                    ],
+                    returns:
+                        "List of matching items with name, artist, album info, and Spotify URLs",
+                    example: `search({ query: "ambient focus music", type: "playlist", limit: 5 })`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "get_currently_playing",
+                    description: "Get the currently playing track with progress",
+                    parameters: [],
+                    returns:
+                        "Current track info including name, artist, album, progress, and device",
+                    example: `get_currently_playing()`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "get_playback_state",
+                    description:
+                        "Get full playback state including device info, shuffle, repeat mode",
+                    parameters: [],
+                    returns:
+                        "Detailed playback state with device, shuffle/repeat settings, and current track",
+                    example: `get_playback_state()`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "play",
+                    description:
+                        "Start or resume playback. Optionally specify what to play. Requires Premium.",
+                    parameters: [
+                        {
+                            name: "uri",
+                            type: "string",
+                            required: false,
+                            description:
+                                "Spotify URI to play (track, album, playlist, artist). If omitted, resumes current playback.",
+                            example: "spotify:track:4iV5W9uYEdYUVa79Axb7Rh",
+                        },
+                        {
+                            name: "device_id",
+                            type: "string",
+                            required: false,
+                            description:
+                                "Device ID to play on. If omitted, uses active device.",
+                        },
+                    ],
+                    returns: "Confirmation that playback started",
+                    example: `play({ uri: "spotify:playlist:37i9dQZF1DX3rxVfibe1L0" })`,
+                    annotations: { readOnlyHint: false, destructiveHint: false },
+                },
+                {
+                    name: "pause",
+                    description: "Pause playback. Requires Premium.",
+                    parameters: [
+                        {
+                            name: "device_id",
+                            type: "string",
+                            required: false,
+                            description:
+                                "Device ID to pause. If omitted, uses active device.",
+                        },
+                    ],
+                    returns: "Confirmation that playback paused",
+                    example: `pause()`,
+                    annotations: { readOnlyHint: false, destructiveHint: false },
+                },
+                {
+                    name: "next",
+                    description: "Skip to next track. Requires Premium.",
+                    parameters: [
+                        {
+                            name: "device_id",
+                            type: "string",
+                            required: false,
+                            description: "Device ID. If omitted, uses active device.",
+                        },
+                    ],
+                    returns: "Confirmation that skipped to next track",
+                    example: `next()`,
+                    annotations: { readOnlyHint: false, destructiveHint: false },
+                },
+                {
+                    name: "previous",
+                    description: "Skip to previous track. Requires Premium.",
+                    parameters: [
+                        {
+                            name: "device_id",
+                            type: "string",
+                            required: false,
+                            description: "Device ID. If omitted, uses active device.",
+                        },
+                    ],
+                    returns: "Confirmation that skipped to previous track",
+                    example: `previous()`,
+                    annotations: { readOnlyHint: false, destructiveHint: false },
+                },
+                {
+                    name: "get_recently_played",
+                    description: "Get recently played tracks",
+                    parameters: [
+                        {
+                            name: "limit",
+                            type: "number",
+                            required: false,
+                            description: "Max tracks to return (1-50, default: 20)",
+                            example: "10",
+                        },
+                    ],
+                    returns: "List of recently played tracks with timestamps",
+                    example: `get_recently_played({ limit: 10 })`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "get_top_items",
+                    description:
+                        "Get user's top artists or tracks based on listening history",
+                    parameters: [
+                        {
+                            name: "type",
+                            type: "string",
+                            required: true,
+                            description: "Type of items: 'artists' or 'tracks'",
+                            example: "artists",
+                        },
+                        {
+                            name: "time_range",
+                            type: "string",
+                            required: false,
+                            description:
+                                "Time range: 'short_term' (~4 weeks), 'medium_term' (~6 months), 'long_term' (~years). Default: medium_term",
+                            example: "short_term",
+                        },
+                        {
+                            name: "limit",
+                            type: "number",
+                            required: false,
+                            description: "Max items to return (1-50, default: 20)",
+                            example: "10",
+                        },
+                    ],
+                    returns: "Top artists or tracks for the specified time period",
+                    example: `get_top_items({ type: "artists", time_range: "short_term", limit: 10 })`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "list_playlists",
+                    description: "Get user's playlists (owned and followed)",
+                    parameters: [
+                        {
+                            name: "limit",
+                            type: "number",
+                            required: false,
+                            description: "Max playlists to return (1-50, default: 20)",
+                            example: "10",
+                        },
+                        {
+                            name: "offset",
+                            type: "number",
+                            required: false,
+                            description: "Offset for pagination (default: 0)",
+                            example: "0",
+                        },
+                    ],
+                    returns:
+                        "List of user's playlists with names, track counts, and owners",
+                    example: `list_playlists({ limit: 20 })`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "get_playlist",
+                    description: "Get playlist details with tracks",
+                    parameters: [
+                        {
+                            name: "playlist_id",
+                            type: "string",
+                            required: true,
+                            description: "Spotify playlist ID",
+                            example: "37i9dQZF1DX3rxVfibe1L0",
+                        },
+                        {
+                            name: "limit",
+                            type: "number",
+                            required: false,
+                            description: "Max tracks to return (1-100, default: 50)",
+                            example: "50",
+                        },
+                    ],
+                    returns:
+                        "Playlist info with tracks including name, artists, and duration",
+                    example: `get_playlist({ playlist_id: "37i9dQZF1DX3rxVfibe1L0" })`,
+                    annotations: { readOnlyHint: true },
+                },
+                {
+                    name: "raw_api",
+                    description:
+                        "Direct Spotify API access for operations not listed above. " +
+                        "Use when you need to access endpoints not covered by standard operations. " +
+                        "Consult: https://developer.spotify.com/documentation/web-api",
+                    parameters: [
+                        {
+                            name: "endpoint",
+                            type: "string",
+                            required: true,
+                            description:
+                                "Spotify API endpoint path (e.g., '/v1/me', '/v1/playlists/{id}')",
+                            example: "/v1/me",
+                        },
+                        {
+                            name: "method",
+                            type: "string",
+                            required: true,
+                            description: "HTTP method (GET, POST, PUT, DELETE)",
+                            example: "GET",
+                        },
+                        {
+                            name: "body",
+                            type: "object",
+                            required: false,
+                            description: "Request body for POST/PUT requests",
+                        },
+                        {
+                            name: "query",
+                            type: "object",
+                            required: false,
+                            description: "Query parameters as key-value pairs",
+                        },
+                    ],
+                    returns: "Raw Spotify API response as JSON",
+                    example: `raw_api({ endpoint: "/v1/me", method: "GET" })`,
+                },
+            ],
+            docsUrl: "https://developer.spotify.com/documentation/web-api",
+        };
+    }
+
+    async execute(
+        action: string,
+        params: unknown,
+        userId: string,
+        accountId?: string
+    ): Promise<MCPToolResponse> {
+        const validation = this.validate(action, params);
+        if (!validation.valid) {
+            this.logError(
+                `[SPOTIFY ADAPTER] Validation failed for action '${action}':`,
+                validation.errors
+            );
+            return this.createErrorResponse(
+                `Validation errors:\n${validation.errors.join("\n")}`
+            );
+        }
+
+        // Get credentials via base adapter helper
+        const tokenResult = await this.getOAuthAccessToken(userId, accountId);
+        if ("content" in tokenResult) {
+            return tokenResult;
+        }
+        const { accessToken } = tokenResult;
+
+        try {
+            switch (action) {
+                case "search":
+                    return await this.handleSearch(params, accessToken);
+                case "get_currently_playing":
+                    return await this.handleGetCurrentlyPlaying(accessToken);
+                case "get_playback_state":
+                    return await this.handleGetPlaybackState(accessToken);
+                case "play":
+                    return await this.handlePlay(params, accessToken);
+                case "pause":
+                    return await this.handlePause(params, accessToken);
+                case "next":
+                    return await this.handleNext(params, accessToken);
+                case "previous":
+                    return await this.handlePrevious(params, accessToken);
+                case "get_recently_played":
+                    return await this.handleGetRecentlyPlayed(params, accessToken);
+                case "get_top_items":
+                    return await this.handleGetTopItems(params, accessToken);
+                case "list_playlists":
+                    return await this.handleListPlaylists(params, accessToken);
+                case "get_playlist":
+                    return await this.handleGetPlaylist(params, accessToken);
+                case "raw_api":
+                    return await this.executeRawAPI(
+                        params as RawAPIParams,
+                        userId,
+                        accountId
+                    );
+                default:
+                    this.logError(
+                        `[SPOTIFY ADAPTER] Unknown action '${action}' requested by user ${userId}`
+                    );
+                    return this.createErrorResponse(
+                        `Unknown action: ${action}. Use action='describe' to see available operations.`
+                    );
+            }
+        } catch (error) {
+            return this.handleOperationError(
+                error,
+                action,
+                params as Record<string, unknown>,
+                userId
+            );
+        }
+    }
+
+    private async handleSearch(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const {
+            query,
+            type = "track",
+            limit = 20,
+        } = params as {
+            query: string;
+            type?: string;
+            limit?: number;
+        };
+
+        const cappedLimit = Math.min(Math.max(1, limit), 50);
+
+        const response = await httpClient
+            .get(`${SPOTIFY_API_BASE}/search`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams: {
+                    q: query,
+                    type,
+                    limit: cappedLimit.toString(),
+                },
+            })
+            .json<{
+                tracks?: { items: SpotifyTrack[] };
+                albums?: { items: SpotifyAlbum[] };
+                artists?: { items: SpotifyArtist[] };
+                playlists?: { items: SpotifyPlaylist[] };
+            }>();
+
+        const results: Record<string, unknown[]> = {};
+
+        if (response.tracks?.items) {
+            results.tracks = response.tracks.items.map(this.formatTrack);
+        }
+        if (response.albums?.items) {
+            results.albums = response.albums.items.map(this.formatAlbum);
+        }
+        if (response.artists?.items) {
+            results.artists = response.artists.items.map(this.formatArtist);
+        }
+        if (response.playlists?.items) {
+            results.playlists = response.playlists.items.map(
+                this.formatPlaylistSummary
+            );
+        }
+
+        return this.createJSONResponse({
+            query,
+            type,
+            ...results,
+            note: "Use Spotify URIs with play() to start playback.",
+        });
+    }
+
+    private async handleGetCurrentlyPlaying(
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        try {
+            const response = await httpClient
+                .get(`${SPOTIFY_API_BASE}/me/player/currently-playing`, {
+                    headers: this.buildHeaders(accessToken),
+                })
+                .json<SpotifyCurrentlyPlaying | null>();
+
+            if (!response || !response.item) {
+                return this.createJSONResponse({
+                    isPlaying: false,
+                    message: "Nothing is currently playing",
+                    note: "Open Spotify on a device to start listening.",
+                });
+            }
+
+            const track = response.item as SpotifyTrack;
+            return this.createJSONResponse({
+                isPlaying: response.is_playing,
+                track: this.formatTrack(track),
+                progressMs: response.progress_ms,
+                progressFormatted: this.formatDuration(response.progress_ms || 0),
+                durationMs: track.duration_ms,
+                durationFormatted: this.formatDuration(track.duration_ms),
+                device: response.device
+                    ? {
+                          name: response.device.name,
+                          type: response.device.type,
+                          volumePercent: response.device.volume_percent,
+                      }
+                    : null,
+            });
+        } catch (error) {
+            // 204 means no active device/playback
+            if (error instanceof Error && error.message.includes("204")) {
+                return this.createJSONResponse({
+                    isPlaying: false,
+                    message: "No active playback",
+                    note: "Open Spotify on a device to start listening.",
+                });
+            }
+            throw error;
+        }
+    }
+
+    private async handleGetPlaybackState(
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        try {
+            const response = await httpClient
+                .get(`${SPOTIFY_API_BASE}/me/player`, {
+                    headers: this.buildHeaders(accessToken),
+                })
+                .json<SpotifyPlaybackState | null>();
+
+            if (!response) {
+                return this.createJSONResponse({
+                    isPlaying: false,
+                    message: "No active playback state",
+                    note: "Open Spotify on a device to start listening.",
+                });
+            }
+
+            const track = response.item as SpotifyTrack | null;
+            return this.createJSONResponse({
+                isPlaying: response.is_playing,
+                shuffleState: response.shuffle_state,
+                repeatState: response.repeat_state,
+                track: track ? this.formatTrack(track) : null,
+                progressMs: response.progress_ms,
+                device: response.device
+                    ? {
+                          id: response.device.id,
+                          name: response.device.name,
+                          type: response.device.type,
+                          isActive: response.device.is_active,
+                          volumePercent: response.device.volume_percent,
+                      }
+                    : null,
+            });
+        } catch (error) {
+            if (error instanceof Error && error.message.includes("204")) {
+                return this.createJSONResponse({
+                    isPlaying: false,
+                    message: "No active playback state",
+                    note: "Open Spotify on a device to start listening.",
+                });
+            }
+            throw error;
+        }
+    }
+
+    private async handlePlay(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { uri, device_id } = params as {
+            uri?: string;
+            device_id?: string;
+        };
+
+        const searchParams: Record<string, string> = {};
+        if (device_id) searchParams.device_id = device_id;
+
+        const body: Record<string, unknown> = {};
+        if (uri) {
+            // Determine if it's a context URI (album, playlist, artist) or track URI
+            if (uri.includes(":track:")) {
+                body.uris = [uri];
+            } else {
+                body.context_uri = uri;
+            }
+        }
+
+        try {
+            await httpClient.put(`${SPOTIFY_API_BASE}/me/player/play`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams:
+                    Object.keys(searchParams).length > 0 ? searchParams : undefined,
+                json: Object.keys(body).length > 0 ? body : undefined,
+            });
+
+            return this.createSuccessResponse(
+                uri ? `🎵 Started playing ${uri}` : "🎵 Resumed playback"
+            );
+        } catch (error) {
+            return this.handlePlaybackError(error, "play");
+        }
+    }
+
+    private async handlePause(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { device_id } = params as { device_id?: string };
+
+        const searchParams: Record<string, string> = {};
+        if (device_id) searchParams.device_id = device_id;
+
+        try {
+            await httpClient.put(`${SPOTIFY_API_BASE}/me/player/pause`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams:
+                    Object.keys(searchParams).length > 0 ? searchParams : undefined,
+            });
+
+            return this.createSuccessResponse("⏸️ Paused playback");
+        } catch (error) {
+            return this.handlePlaybackError(error, "pause");
+        }
+    }
+
+    private async handleNext(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { device_id } = params as { device_id?: string };
+
+        const searchParams: Record<string, string> = {};
+        if (device_id) searchParams.device_id = device_id;
+
+        try {
+            await httpClient.post(`${SPOTIFY_API_BASE}/me/player/next`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams:
+                    Object.keys(searchParams).length > 0 ? searchParams : undefined,
+            });
+
+            return this.createSuccessResponse("⏭️ Skipped to next track");
+        } catch (error) {
+            return this.handlePlaybackError(error, "skip");
+        }
+    }
+
+    private async handlePrevious(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { device_id } = params as { device_id?: string };
+
+        const searchParams: Record<string, string> = {};
+        if (device_id) searchParams.device_id = device_id;
+
+        try {
+            await httpClient.post(`${SPOTIFY_API_BASE}/me/player/previous`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams:
+                    Object.keys(searchParams).length > 0 ? searchParams : undefined,
+            });
+
+            return this.createSuccessResponse("⏮️ Skipped to previous track");
+        } catch (error) {
+            return this.handlePlaybackError(error, "go back");
+        }
+    }
+
+    private async handleGetRecentlyPlayed(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { limit = 20 } = params as { limit?: number };
+        const cappedLimit = Math.min(Math.max(1, limit), 50);
+
+        const response = await httpClient
+            .get(`${SPOTIFY_API_BASE}/me/player/recently-played`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams: {
+                    limit: cappedLimit.toString(),
+                },
+            })
+            .json<{
+                items: Array<{
+                    track: SpotifyTrack;
+                    played_at: string;
+                }>;
+            }>();
+
+        return this.createJSONResponse({
+            totalCount: response.items.length,
+            tracks: response.items.map((item) => ({
+                ...this.formatTrack(item.track),
+                playedAt: item.played_at,
+            })),
+        });
+    }
+
+    private async handleGetTopItems(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const {
+            type,
+            time_range = "medium_term",
+            limit = 20,
+        } = params as {
+            type: "artists" | "tracks";
+            time_range?: "short_term" | "medium_term" | "long_term";
+            limit?: number;
+        };
+
+        const cappedLimit = Math.min(Math.max(1, limit), 50);
+
+        const response = await httpClient
+            .get(`${SPOTIFY_API_BASE}/me/top/${type}`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams: {
+                    time_range,
+                    limit: cappedLimit.toString(),
+                },
+            })
+            .json<{
+                items: SpotifyTrack[] | SpotifyArtist[];
+            }>();
+
+        const timeRangeLabel =
+            time_range === "short_term"
+                ? "last 4 weeks"
+                : time_range === "long_term"
+                  ? "all time"
+                  : "last 6 months";
+
+        if (type === "artists") {
+            return this.createJSONResponse({
+                type: "artists",
+                timeRange: timeRangeLabel,
+                totalCount: response.items.length,
+                artists: (response.items as SpotifyArtist[]).map(this.formatArtist),
+            });
+        } else {
+            return this.createJSONResponse({
+                type: "tracks",
+                timeRange: timeRangeLabel,
+                totalCount: response.items.length,
+                tracks: (response.items as SpotifyTrack[]).map(this.formatTrack),
+            });
+        }
+    }
+
+    private async handleListPlaylists(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { limit = 20, offset = 0 } = params as {
+            limit?: number;
+            offset?: number;
+        };
+
+        const cappedLimit = Math.min(Math.max(1, limit), 50);
+
+        const response = await httpClient
+            .get(`${SPOTIFY_API_BASE}/me/playlists`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams: {
+                    limit: cappedLimit.toString(),
+                    offset: offset.toString(),
+                },
+            })
+            .json<{
+                items: SpotifyPlaylist[];
+                total: number;
+            }>();
+
+        return this.createJSONResponse({
+            totalCount: response.total,
+            returnedCount: response.items.length,
+            offset,
+            playlists: response.items.map(this.formatPlaylistSummary),
+            note: "Use get_playlist with a playlist_id for full track listing.",
+        });
+    }
+
+    private async handleGetPlaylist(
+        params: unknown,
+        accessToken: string
+    ): Promise<MCPToolResponse> {
+        const { playlist_id, limit = 50 } = params as {
+            playlist_id: string;
+            limit?: number;
+        };
+
+        const cappedLimit = Math.min(Math.max(1, limit), 100);
+
+        const response = await httpClient
+            .get(`${SPOTIFY_API_BASE}/playlists/${playlist_id}`, {
+                headers: this.buildHeaders(accessToken),
+                searchParams: {
+                    limit: cappedLimit.toString(),
+                },
+            })
+            .json<SpotifyPlaylistFull>();
+
+        return this.createJSONResponse({
+            id: response.id,
+            name: response.name,
+            description: response.description,
+            owner: response.owner.display_name || response.owner.id,
+            public: response.public,
+            collaborative: response.collaborative,
+            totalTracks: response.tracks.total,
+            returnedTracks: response.tracks.items.length,
+            uri: response.uri,
+            url: response.external_urls.spotify,
+            tracks: response.tracks.items
+                .filter((item) => item.track)
+                .map((item) => this.formatTrack(item.track as SpotifyTrack)),
+            note:
+                response.tracks.total > response.tracks.items.length
+                    ? `Showing first ${response.tracks.items.length} of ${response.tracks.total} tracks. Use raw_api to paginate.`
+                    : undefined,
+        });
+    }
+
+    /**
+     * Execute a raw Spotify API request
+     */
+    async executeRawAPI(
+        params: RawAPIParams,
+        userId: string,
+        accountId?: string
+    ): Promise<MCPToolResponse> {
+        const { endpoint, method, body, query } = params;
+
+        if (!endpoint || typeof endpoint !== "string") {
+            return this.createErrorResponse(
+                "raw_api requires 'endpoint' parameter (string)"
+            );
+        }
+        if (!method || typeof method !== "string") {
+            return this.createErrorResponse(
+                "raw_api requires 'method' parameter (GET, POST, PUT, DELETE)"
+            );
+        }
+
+        if (!endpoint.startsWith("/v1")) {
+            return this.createErrorResponse(
+                "Invalid endpoint: must start with '/v1'. " +
+                    `Got: ${endpoint}. Example: '/v1/me'`
+            );
+        }
+
+        const tokenResult = await this.getOAuthAccessToken(userId, accountId);
+        if ("content" in tokenResult) {
+            return tokenResult;
+        }
+        const { accessToken } = tokenResult;
+
+        const requestOptions: {
+            headers: Record<string, string>;
+            searchParams?: Record<string, string>;
+            json?: Record<string, unknown>;
+        } = {
+            headers: this.buildHeaders(accessToken),
+        };
+
+        if (query && typeof query === "object") {
+            requestOptions.searchParams = Object.fromEntries(
+                Object.entries(query).map(([k, v]) => [k, String(v)])
+            );
+        }
+
+        if (["POST", "PUT", "PATCH"].includes(method.toUpperCase()) && body) {
+            requestOptions.json = body;
+        }
+
+        try {
+            const httpMethod = method.toLowerCase() as
+                | "get"
+                | "post"
+                | "put"
+                | "delete"
+                | "patch";
+            const fullUrl = `https://api.spotify.com${endpoint}`;
+
+            const response = await httpClient[httpMethod](fullUrl, requestOptions).json<
+                Record<string, unknown>
+            >();
+
+            return this.createJSONResponse(response);
+        } catch (error) {
+            this.captureAndLogError(error, {
+                action: "raw_api",
+                params: { endpoint, method },
+                userId,
+            });
+
+            let errorMessage = `Raw API request failed: `;
+            if (error instanceof Error) {
+                if (error.message.includes("404")) {
+                    errorMessage +=
+                        "Endpoint not found. Check the Spotify API docs: https://developer.spotify.com/documentation/web-api";
+                } else {
+                    errorMessage += this.getAPIErrorDescription(error);
+                }
+            } else {
+                errorMessage += "Unknown error";
+            }
+
+            return this.createErrorResponse(errorMessage);
+        }
+    }
+
+    /**
+     * Handle playback-specific errors (Premium required, no active device, etc.)
+     */
+    private handlePlaybackError(error: unknown, action: string): MCPToolResponse {
+        if (!(error instanceof Error)) {
+            return this.createErrorResponse(
+                `Couldn't ${action}: The bots have been alerted. 🤖`
+            );
+        }
+
+        const errMsg = error.message;
+
+        // Premium required
+        if (errMsg.includes("403") || errMsg.includes("PREMIUM_REQUIRED")) {
+            return this.createErrorResponse(
+                `🔒 Spotify Premium required to ${action}. ` +
+                    "Playback control is only available for Premium subscribers."
+            );
+        }
+
+        // No active device
+        if (errMsg.includes("404") || errMsg.includes("NO_ACTIVE_DEVICE")) {
+            return this.createErrorResponse(
+                `📱 No active Spotify device found. ` +
+                    "Open Spotify on a device first, then try again."
+            );
+        }
+
+        // Rate limit
+        if (errMsg.includes("429")) {
+            return this.createErrorResponse(
+                `⏳ Spotify rate limit hit. Give it a moment and try again.`
+            );
+        }
+
+        return this.createErrorResponse(`Couldn't ${action}: ${errMsg}`);
+    }
+
+    /**
+     * Format duration from milliseconds to human-readable string
+     */
+    private formatDuration(ms: number): string {
+        const minutes = Math.floor(ms / 60000);
+        const seconds = Math.floor((ms % 60000) / 1000);
+        return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+    }
+
+    /**
+     * Format a Spotify track for output
+     */
+    private formatTrack = (track: SpotifyTrack): Record<string, unknown> => ({
+        id: track.id,
+        name: track.name,
+        artists: track.artists.map((a) => a.name).join(", "),
+        album: track.album?.name,
+        duration: this.formatDuration(track.duration_ms),
+        durationMs: track.duration_ms,
+        uri: track.uri,
+        url: track.external_urls.spotify,
+    });
+
+    /**
+     * Format a Spotify album for output
+     */
+    private formatAlbum = (album: SpotifyAlbum): Record<string, unknown> => ({
+        id: album.id,
+        name: album.name,
+        artists: album.artists.map((a) => a.name).join(", "),
+        releaseDate: album.release_date,
+        totalTracks: album.total_tracks,
+        uri: album.uri,
+        url: album.external_urls.spotify,
+    });
+
+    /**
+     * Format a Spotify artist for output
+     */
+    private formatArtist = (artist: SpotifyArtist): Record<string, unknown> => ({
+        id: artist.id,
+        name: artist.name,
+        genres: artist.genres,
+        followers: artist.followers?.total,
+        popularity: artist.popularity,
+        uri: artist.uri,
+        url: artist.external_urls.spotify,
+    });
+
+    /**
+     * Format a Spotify playlist summary for output
+     */
+    private formatPlaylistSummary = (
+        playlist: SpotifyPlaylist
+    ): Record<string, unknown> => ({
+        id: playlist.id,
+        name: playlist.name,
+        description: playlist.description,
+        owner: playlist.owner.display_name || playlist.owner.id,
+        public: playlist.public,
+        trackCount: playlist.tracks.total,
+        uri: playlist.uri,
+        url: playlist.external_urls.spotify,
+    });
+}
+
+// Type definitions for Spotify API responses
+interface SpotifyTrack {
+    id: string;
+    name: string;
+    artists: Array<{ name: string }>;
+    album?: { name: string };
+    duration_ms: number;
+    uri: string;
+    external_urls: { spotify: string };
+}
+
+interface SpotifyAlbum {
+    id: string;
+    name: string;
+    artists: Array<{ name: string }>;
+    release_date: string;
+    total_tracks: number;
+    uri: string;
+    external_urls: { spotify: string };
+}
+
+interface SpotifyArtist {
+    id: string;
+    name: string;
+    genres?: string[];
+    followers?: { total: number };
+    popularity?: number;
+    uri: string;
+    external_urls: { spotify: string };
+}
+
+interface SpotifyPlaylist {
+    id: string;
+    name: string;
+    description: string | null;
+    owner: { id: string; display_name: string | null };
+    public: boolean;
+    tracks: { total: number };
+    uri: string;
+    external_urls: { spotify: string };
+}
+
+interface SpotifyPlaylistFull extends SpotifyPlaylist {
+    collaborative: boolean;
+    tracks: {
+        total: number;
+        items: Array<{
+            track: SpotifyTrack | null;
+            added_at: string;
+        }>;
+    };
+}
+
+interface SpotifyDevice {
+    id: string;
+    name: string;
+    type: string;
+    is_active: boolean;
+    volume_percent: number;
+}
+
+interface SpotifyCurrentlyPlaying {
+    is_playing: boolean;
+    progress_ms: number | null;
+    item: SpotifyTrack | null;
+    device?: SpotifyDevice;
+}
+
+interface SpotifyPlaybackState {
+    is_playing: boolean;
+    shuffle_state: boolean;
+    repeat_state: string;
+    progress_ms: number | null;
+    item: SpotifyTrack | null;
+    device: SpotifyDevice | null;
+}

--- a/lib/integrations/oauth/providers/index.ts
+++ b/lib/integrations/oauth/providers/index.ts
@@ -13,6 +13,7 @@ import { clickupProvider } from "./clickup";
 import { dropboxProvider } from "./dropbox";
 import { googleCalendarContactsProvider } from "./google-calendar-contacts";
 import { gmailProvider } from "./gmail";
+import { spotifyProvider } from "./spotify";
 import { twitterProvider } from "./twitter";
 
 /**
@@ -20,12 +21,13 @@ import { twitterProvider } from "./twitter";
  * Key is the provider ID that matches the service registry.
  */
 const providers: Record<string, OAuthProviderConfig> = {
-    notion: notionProvider,
-    slack: slackProvider,
     clickup: clickupProvider,
     dropbox: dropboxProvider,
-    "google-calendar-contacts": googleCalendarContactsProvider,
     gmail: gmailProvider,
+    "google-calendar-contacts": googleCalendarContactsProvider,
+    notion: notionProvider,
+    slack: slackProvider,
+    spotify: spotifyProvider,
     twitter: twitterProvider,
 };
 
@@ -111,21 +113,23 @@ export function buildAuthorizationUrl(
     return authUrl;
 }
 
-// Re-export for convenience
-export { notionProvider } from "./notion";
-export { NOTION_API_BASE, NOTION_API_VERSION } from "./notion";
-export { slackProvider } from "./slack";
-export { SLACK_API_BASE } from "./slack";
+// Re-export for convenience (alphabetical order)
 export { clickupProvider } from "./clickup";
 export { CLICKUP_API_BASE } from "./clickup";
 export { dropboxProvider } from "./dropbox";
 export { DROPBOX_API_BASE, DROPBOX_CONTENT_API_BASE } from "./dropbox";
+export { gmailProvider } from "./gmail";
+export { GMAIL_API_BASE } from "./gmail";
 export { googleCalendarContactsProvider } from "./google-calendar-contacts";
 export {
     GOOGLE_CALENDAR_API_BASE,
     GOOGLE_PEOPLE_API_BASE,
 } from "./google-calendar-contacts";
-export { gmailProvider } from "./gmail";
-export { GMAIL_API_BASE } from "./gmail";
+export { notionProvider } from "./notion";
+export { NOTION_API_BASE, NOTION_API_VERSION } from "./notion";
+export { slackProvider } from "./slack";
+export { SLACK_API_BASE } from "./slack";
+export { spotifyProvider } from "./spotify";
+export { SPOTIFY_API_BASE } from "./spotify";
 export { twitterProvider } from "./twitter";
 export { TWITTER_API_BASE } from "./twitter";

--- a/lib/integrations/oauth/providers/spotify.ts
+++ b/lib/integrations/oauth/providers/spotify.ts
@@ -1,0 +1,102 @@
+/**
+ * Spotify OAuth Provider Configuration
+ *
+ * Spotify uses OAuth 2.0 with PKCE for music streaming integration.
+ * - Uses Authorization Code Flow with PKCE (no client secret required for PKCE)
+ * - Token response includes access_token and refresh_token
+ * - Access tokens expire after 1 hour
+ * - Scopes control access to user data and playback control
+ */
+
+import { env } from "@/lib/env";
+import type { OAuthProviderConfig } from "../types";
+
+export const spotifyProvider: OAuthProviderConfig = {
+    id: "spotify",
+
+    authorizationUrl: "https://accounts.spotify.com/authorize",
+    tokenUrl: "https://accounts.spotify.com/api/token",
+
+    // Comprehensive scopes for music discovery, playback control, and insights
+    scopes: [
+        "user-read-currently-playing", // What's playing now
+        "user-read-playback-state", // Device info, playback details
+        "user-modify-playback-state", // Play/pause/skip/seek
+        "user-read-recently-played", // Recently played tracks
+        "user-top-read", // Top artists and tracks
+        "user-library-read", // Saved albums/tracks/shows
+        "playlist-read-private", // Access private playlists
+        "playlist-read-collaborative", // Access collaborative playlists
+        "user-read-email", // User identifier for account info
+        "user-read-private", // Subscription details
+    ],
+
+    /**
+     * Extract account info from Spotify's user profile.
+     *
+     * Spotify returns user info at /v1/me endpoint after authentication.
+     * We use email as identifier and display_name for display.
+     */
+    extractAccountInfo: async (response, accessToken) => {
+        if (!accessToken) {
+            throw new Error("Access token required to fetch Spotify account info");
+        }
+
+        // Import httpClient and monitoring tools dynamically to avoid circular dependencies
+        const { httpClient } = await import("@/lib/http-client");
+        const { logger } = await import("@/lib/logger");
+        const Sentry = await import("@sentry/nextjs");
+
+        try {
+            const userResponse = await httpClient
+                .get("https://api.spotify.com/v1/me", {
+                    headers: {
+                        Authorization: `Bearer ${accessToken}`,
+                        "Content-Type": "application/json",
+                    },
+                })
+                .json<{
+                    id: string;
+                    display_name: string | null;
+                    email: string;
+                }>();
+
+            return {
+                identifier: userResponse.email || userResponse.id,
+                displayName:
+                    userResponse.display_name || userResponse.email || userResponse.id,
+            };
+        } catch (error) {
+            logger.error(
+                { error, provider: "spotify", endpoint: "v1/me" },
+                "Failed to fetch Spotify account info"
+            );
+            Sentry.captureException(error, {
+                tags: { component: "oauth", provider: "spotify" },
+            });
+            throw new Error(`Couldn't reach Spotify right now. Give it another try?`);
+        }
+    },
+
+    // These are populated at runtime from env
+    get clientId(): string {
+        const id = env.SPOTIFY_CLIENT_ID;
+        if (!id) {
+            throw new Error("SPOTIFY_CLIENT_ID environment variable is required");
+        }
+        return id;
+    },
+
+    get clientSecret(): string {
+        const secret = env.SPOTIFY_CLIENT_SECRET;
+        if (!secret) {
+            throw new Error("SPOTIFY_CLIENT_SECRET environment variable is required");
+        }
+        return secret;
+    },
+};
+
+/**
+ * Spotify API base URL for direct calls
+ */
+export const SPOTIFY_API_BASE = "https://api.spotify.com/v1";

--- a/lib/integrations/services.ts
+++ b/lib/integrations/services.ts
@@ -247,6 +247,27 @@ export const SERVICE_REGISTRY: ServiceDefinition[] = [
         ],
     },
 
+    // Spotify - OAuth (in-house)
+    {
+        id: "spotify",
+        name: "Spotify",
+        description: "Music discovery, playback control, and listening insights",
+        logo: "/logos/spotify.svg",
+        authMethod: "oauth",
+        status: "available",
+        oauthProviderId: "spotify",
+        supportsMultipleAccounts: true,
+        docsUrl: "https://developer.spotify.com/documentation/web-api",
+        capabilities: [
+            "search",
+            "get_currently_playing",
+            "play",
+            "pause",
+            "get_top_items",
+            "list_playlists",
+        ],
+    },
+
     // Twitter/X - OAuth (in-house)
     {
         id: "twitter",

--- a/lib/integrations/tools.ts
+++ b/lib/integrations/tools.ts
@@ -25,6 +25,7 @@ import {
     NotionAdapter,
     QuoAdapter,
     SlackAdapter,
+    SpotifyAdapter,
     TwitterAdapter,
 } from "./adapters";
 import type { ServiceAdapter } from "./adapters/base";
@@ -48,6 +49,7 @@ const adapterMap: Record<string, ServiceAdapter> = {
     notion: new NotionAdapter(),
     quo: new QuoAdapter(),
     slack: new SlackAdapter(),
+    spotify: new SpotifyAdapter(),
     twitter: new TwitterAdapter(),
 };
 

--- a/lib/tools/tool-config.ts
+++ b/lib/tools/tool-config.ts
@@ -432,6 +432,32 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
             fast: ["Quick send!", "Sent!"],
         },
     },
+    spotify: {
+        displayName: "Spotify",
+        icon: "/logos/spotify.svg",
+        getDescription: (args) => {
+            const action = args.action as string | undefined;
+            if (action === "search") {
+                const query = args.params as { query?: string } | undefined;
+                return query?.query ? truncate(query.query, 30) : "searching";
+            }
+            if (action === "get_currently_playing") return "now playing";
+            if (action === "play") return "playing";
+            if (action === "pause") return "pausing";
+            if (action === "next" || action === "previous") return "skipping";
+            return action;
+        },
+        messages: {
+            pending: "Getting ready...",
+            running: "Connecting to Spotify...",
+            completed: "Spotify ready",
+            error: "Couldn't complete Spotify operation",
+        },
+        delightMessages: {
+            completed: ["Music flowing", "Tuned in", "Sound check done", "Vibes ready"],
+            fast: ["Quick beats!", "Instant tune"],
+        },
+    },
     twitter: {
         displayName: "X (Twitter)",
         icon: "/logos/twitter.svg",


### PR DESCRIPTION
## Summary

Adds complete Spotify integration with OAuth 2.0 authentication and 11 core operations:

- **Search**: Find tracks, albums, artists, playlists, and podcasts
- **Playback Control**: Play, pause, next, previous tracks
- **Now Playing**: Get currently playing track and full playback state
- **Listening History**: Recently played tracks and top items (artists/tracks by time range)
- **Playlists**: List user playlists and get playlist details with tracks

## Implementation

**New Files:**
- `lib/integrations/oauth/providers/spotify.ts` - OAuth provider configuration with PKCE flow
- `lib/integrations/adapters/spotify.ts` - Service adapter with all 11 operations + raw_api
- `__tests__/unit/lib/integrations/adapters/spotify.test.ts` - 21 unit tests

**Modified Files:**
- OAuth provider registry exports
- Adapter registry exports
- Service registry entry
- Tool configuration for UI
- Environment variable definitions

## Design Decisions

- **OAuth Scopes**: Included all necessary scopes for the 11 operations plus user profile scopes for account info display
- **Error Handling**: Specific handling for Premium-required errors (403) and no active device errors—returns user-friendly messages rather than raw API errors
- **Playback API Shape**: Returns normalized data with clear structure (currently_playing vs playback_state) for different levels of detail

## Test Plan

- [x] All 21 adapter unit tests pass
- [x] OAuth provider count test updated (7 → 8)
- [x] Full test suite passes (2070 tests)
- [x] TypeScript type check passes
- [x] Lint passes (warnings only, no errors)

Fixes #607

Generated with Carmenta