### PR TITLE
🐛 Fix employee crash on malformed AI SDK responses

### DIFF
--- a/__tests__/unit/lib/agents/employee.test.ts
+++ b/__tests__/unit/lib/agents/employee.test.ts
@@ -446,8 +446,8 @@ describe("runEmployee", () => {
 
         const result = await runEmployee(baseInput);
 
-        // Should still succeed but summary will be undefined from args
+        // Empty args object should fall back to text (no summary present)
         expect(result.success).toBe(true);
-        expect(result.summary).toBeUndefined();
+        expect(result.summary).toBe("Fallback text");
     });
 });


### PR DESCRIPTION
## Summary

- Fix crash when AI SDK returns `complete` tool call with undefined/null `args`
- Add defensive handling for empty string text responses
- Add 16 unit tests covering edge cases

## Problem

Jobs were failing with:
```
TypeError: Cannot read properties of undefined (reading 'summary')
```

The AI SDK can return a tool call object where `args` is `undefined` or `null` (malformed response). The previous code checked `if (completeCall)` and `if (completeCallData !== null)` which both pass when args is undefined.

## Solution

1. **Non-streaming path**: Extract args before truthiness check
2. **Streaming path**: Change `!== null` to truthiness check
3. **Fallback text**: Use `||` instead of `??` to catch empty strings

## Test plan

- [x] Added unit tests for undefined args
- [x] Added unit tests for null args  
- [x] Added unit tests for empty string fallback
- [x] All 2073 tests pass
- [x] Multi-agent code review (logic, error handling, test quality, robustness)

Generated with Carmenta