### PR TITLE
🐛 Fix error boundaries capturing all errors to Sentry

### DIFF
--- a/app/api/cron/cleanup-oauth-states/route.ts
+++ b/app/api/cron/cleanup-oauth-states/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { logger } from "@/lib/logger";
 import { cleanupExpiredStates } from "@/lib/integrations/oauth/state";
+import { serverErrorResponse, unauthorizedResponse } from "@/lib/api/responses";
 
 /**
  * Cron job to clean up expired OAuth state tokens.
@@ -21,7 +22,7 @@ export async function GET(request: NextRequest) {
                 { endpoint: "cleanup-oauth-states" },
                 "Unauthorized cron request"
             );
-            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+            return unauthorizedResponse("Unauthorized");
         }
     }
 
@@ -36,14 +37,6 @@ export async function GET(request: NextRequest) {
             timestamp: new Date().toISOString(),
         });
     } catch (error) {
-        logger.error({ error }, "Failed to clean up OAuth states");
-
-        return NextResponse.json(
-            {
-                success: false,
-                error: error instanceof Error ? error.message : "Unknown error",
-            },
-            { status: 500 }
-        );
+        return serverErrorResponse(error, { route: "cron/cleanup-oauth-states" });
     }
 }


### PR DESCRIPTION
## Summary

This PR makes two key improvements to error handling:

### 1. Error Boundaries Now Capture ALL Errors

Previously, error boundaries (`app/error.tsx` and `app/global-error.tsx`) only captured errors to Sentry on the **second occurrence** (when the error persisted after auto-refresh). First-time errors were completely lost from observability.

**Before:** First error → auto-refresh (error lost) → Second error → Sentry

**After:** First error → Sentry (warning) + auto-refresh → Second error → Sentry (error)

- First-time errors are now captured at `level: warning` with `willAutoRefresh: true`
- Persistent errors (second occurrence within 30s) are captured at `level: error`
- Both include `persistent: true/false` tag for filtering in Sentry

### 2. API Routes Use serverErrorResponse

Converted notification routes to use `serverErrorResponse` for consistent error handling with automatic Sentry integration:

- `/api/notifications/mark-read` 
- `/api/notifications/mark-all-read`
- `/api/cron/cleanup-oauth-states`

## Audit Findings

After reviewing 160+ try/catch blocks across the codebase:

**Most are intentional and correct:**
- Graceful degradation (localStorage, voice permissions, haptic feedback)
- File system checks (ENOENT expected)
- Retry logic with rethrow
- Specific error type handling
- Adapter tool calls that need structured error responses for AI agents

**The key issues fixed:**
1. Error boundaries were information sinks (first error lost)
2. A few API routes were missing Sentry reporting

## Testing

- All unit tests pass
- Type-check passes