### PR TITLE
✨ Add 'Try it' button for immediate automation testing

### DIFF
--- a/app/ai-team/page.tsx
+++ b/app/ai-team/page.tsx
@@ -88,7 +88,6 @@ function AITeamContent() {
         const hired = searchParams.get("hired");
         const updated = searchParams.get("updated");
         const deleted = searchParams.get("deleted");
-        const triggered = searchParams.get("triggered");
 
         if (hired === "true") {
             setSuccessMessage("New team member hired successfully!");
@@ -96,12 +95,10 @@ function AITeamContent() {
             setSuccessMessage("Automation updated successfully!");
         } else if (deleted === "true") {
             setSuccessMessage("Automation deleted.");
-        } else if (triggered === "true") {
-            setSuccessMessage("Automation started! Watch for it in the activity feed.");
         }
 
         // Clear the query params without triggering a refresh
-        if (hired || updated || deleted || triggered) {
+        if (hired || updated || deleted) {
             router.replace("/ai-team", { scroll: false });
         }
     }, [searchParams, router]);


### PR DESCRIPTION
## Summary

Users can now test their AI automations instantly from the edit form instead of waiting for the next scheduled run. This addresses a key pain point in development workflow - waiting for scheduled jobs to trigger just to test changes.

**What it does:**
- Adds a "Try it" button to the automation edit form
- Triggers immediate execution via existing `/api/jobs/:jobId/trigger` endpoint
- Opens live progress modal to watch the agent work in real-time
- Polls for the new run with proper error handling and timestamp filtering

## Design Decisions

**"Try it" vs "Run Now"**: Multi-agent review included copy review against Carmenta voice guidelines. "Try it" is warmer and more inviting than the transactional "Run Now".

**Disabled when dirty**: Button is disabled when there are unsaved changes. This prevents confusion where users would accidentally run the old saved version instead of their edits. Tooltip explains: "Save changes first".

**Polling with error tracking**: Instead of silently swallowing all errors, the polling loop now:
- Tracks consecutive failures and bails after 3
- Filters by timestamp to avoid matching pre-existing runs
- Uses correct data path (`data.job.runs` not `data.runs`)

**Fallback UX**: If polling times out, shows inline message "Started in the background" rather than claiming false success.

## Test plan

- [ ] Navigate to `/ai-team/{slug}/{id}` for any automation
- [ ] Verify "Try it" button appears between Cancel and Save
- [ ] Verify button is disabled when form has unsaved changes
- [ ] Click "Try it" with no changes - should show "Starting..." then progress modal
- [ ] Test with Temporal running - should show live execution
- [ ] Test error case - should show appropriate error message

Generated with Carmenta