### PR TITLE
✨ Intelligent Save button states for KB content editor

### DIFF
--- a/components/knowledge-viewer/kb-content.tsx
+++ b/components/knowledge-viewer/kb-content.tsx
@@ -441,14 +441,22 @@ export function KBContent({
                         {/* Save Button - intelligent states */}
                         <button
                             onClick={handleSave}
-                            disabled={displaySaveState !== "unsaved" || isOverLimit}
+                            disabled={
+                                (displaySaveState !== "unsaved" &&
+                                    displaySaveState !== "error") ||
+                                isOverLimit
+                            }
                             className={cn(
                                 "flex min-h-[44px] items-center gap-1.5 rounded-lg px-4 py-2",
                                 "text-sm font-medium transition-all duration-150",
                                 "focus-visible:ring-primary/40 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none",
                                 // State-based styling
-                                displaySaveState === "unsaved" && !isOverLimit
-                                    ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                                (displaySaveState === "unsaved" ||
+                                    displaySaveState === "error") &&
+                                    !isOverLimit
+                                    ? displaySaveState === "error"
+                                        ? "bg-red-500 text-white hover:bg-red-600"
+                                        : "bg-primary text-primary-foreground hover:bg-primary/90"
                                     : "bg-primary/50 text-primary-foreground/70 cursor-not-allowed",
                                 isOverLimit && "bg-foreground/10 text-foreground/40"
                             )}


### PR DESCRIPTION
## Summary

- Save/Reset buttons now always visible with intelligent state-based styling
- Save button shows "Save" when idle/pristine, "Save" when dirty, "Saving..." during save, "Saved" after successful save
- Renamed "Revert" to "Reset" for clearer UX
- Removed anachronistic floppy disk icon (modern AI app)
- Removed ⌘S keyboard hint from UI (functionality preserved)
- Added ARIA live region for screen reader accessibility
- Consistent cursor-not-allowed on disabled states

## Test plan

- [ ] Visit /knowledge-base, verify Save button shows "Save" when no changes
- [ ] Make edits, verify button becomes active and shows "Save"
- [ ] Click Save, verify "Saving..." with spinner appears
- [ ] After save completes, verify "Saved" with checkmark appears briefly
- [ ] Verify Reset button is disabled when no changes
- [ ] Verify Reset button is enabled when changes exist
- [ ] Test Cmd+S still works

Generated with Carmenta