### PR TITLE
✨ Improve integration card layout with two-line rows

### DIFF
--- a/components/integrations/multi-account-service-card.tsx
+++ b/components/integrations/multi-account-service-card.tsx
@@ -217,19 +217,19 @@ export function MultiAccountServiceCard({
                                 <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
                                     {/* Left: Status or default badge */}
                                     <div className="flex items-center gap-2">
-                                        {account.isDefault ? (
+                                        {needsAttention ? (
+                                            <span className="text-xs text-amber-600 dark:text-amber-400">
+                                                {account.status === "expired"
+                                                    ? "Authorization expired"
+                                                    : "Needs attention"}
+                                            </span>
+                                        ) : account.isDefault ? (
                                             <span className="text-primary flex items-center gap-1 text-xs font-medium">
                                                 <Star
                                                     className="h-3 w-3"
                                                     weight="fill"
                                                 />
                                                 Default account
-                                            </span>
-                                        ) : needsAttention ? (
-                                            <span className="text-xs text-amber-600 dark:text-amber-400">
-                                                {account.status === "expired"
-                                                    ? "Authorization expired"
-                                                    : "Needs attention"}
                                             </span>
                                         ) : (
                                             <span className="text-muted-foreground text-xs">


### PR DESCRIPTION
## Summary

- Redesigned integration cards to use a two-line row layout instead of cramped horizontal rows
- **Line 1**: Full email/account identifier displayed without truncation
- **Line 2**: Status text on left, action buttons with icons on right
- Added clear Phosphor icons for all actions (ShieldCheck, LinkBreak, ArrowsClockwise, Star)
- Action buttons now have hover backgrounds so they look clearly clickable
- Mobile-friendly: text labels hide on small screens, icons remain visible
- Reduced Connect button size from xl to lg for better visual balance

## Before
- Email addresses truncated (gorillamania@gmai...)
- Actions competed for horizontal space
- Plain text buttons didn't look clickable

## After
- Full emails visible
- Two-line layout gives breathing room
- Icon + text buttons with hover states

## Test plan
- [ ] View integration cards with multiple accounts
- [ ] Verify full email addresses display without truncation
- [ ] Test action buttons (Verify, Set default, Disconnect) 
- [ ] Check mobile layout collapses gracefully
- [ ] Test expired account state shows Reconnect button

Generated with Carmenta