### PR TITLE
🐛 Improve librarian document name validation guidance

### DIFF
--- a/lib/ai-team/librarian/tools.ts
+++ b/lib/ai-team/librarian/tools.ts
@@ -98,7 +98,11 @@ export const createDocumentTool = tool({
             .describe(
                 "Document path in dot notation. Follow conventions: 'profile.identity' for core identity facts, 'knowledge.people.{Name}' for people, 'knowledge.preferences.{category}' for preferences, 'knowledge.projects.{name}' for projects, 'knowledge.decisions.{topic}' for decisions."
             ),
-        name: z.string().describe("Human-readable document name"),
+        name: z
+            .string()
+            .describe(
+                'Human-readable document name (like a filename). Must not contain ".." or "/" characters. Simple names like "Identity", "Sarah", "Carmenta Project" work well.'
+            ),
         content: z.string().describe("Document content in plain text"),
         description: z
             .string()


### PR DESCRIPTION
## Summary
Fixes CARMENTA-1M: Librarian agent creating documents with invalid names containing ".." or "/" characters.

## Root Cause
The librarian agent was calling `create_document` with document names containing path traversal characters (".." or "/"). While the security validation correctly rejected these attempts, the tool description didn't explicitly warn the agent about these constraints, leading to confusion about what goes in the `path` (hierarchical structure) vs `name` (display name) parameters.

## Changes
Enhanced the `name` parameter description in `createDocumentTool`:
- Added explicit constraint: "Must not contain '..' or '/'"
- Provided clear examples of valid names ("Identity", "Sarah", "Carmenta Project")
- Positioned it as "like a filename" to make constraints intuitive

## Why This Works
Tool-use models rely heavily on parameter descriptions for correct usage. Making constraints explicit in the schema description prevents the model from passing invalid values. This is a prompt engineering fix rather than a code fix - the validation logic was already correct.

## Testing
- Existing tests pass
- The error was already being caught gracefully and returned to the agent as a tool result
- With clearer guidance, the agent should avoid triggering this validation error

## Error Details
- **Sentry:** https://carmenta-collective-6a.sentry.io/issues/7164200082/
- **Occurrences:** 2 (2026-01-04 22:02 UTC)
- **Impact:** Minor - agent receives error message and can retry with valid name
- **Priority:** P2 (low occurrence, graceful degradation)

Generated with Carmenta