### PR TITLE
Fix Carmenta sidebar layout on integrations page

### DIFF
--- a/components/ui/holographic-background.tsx
+++ b/components/ui/holographic-background.tsx
@@ -716,7 +716,7 @@ export function HolographicBackground({
             {/* Holographic blobs layer */}
             <canvas
                 ref={holoCanvasRef}
-                className="z-base fixed inset-0"
+                className="z-base pointer-events-none fixed inset-0"
                 style={{ backgroundColor: canvasBgColor }}
                 aria-hidden="true"
             />


### PR DESCRIPTION
## Summary
- Fixed integrations page Carmenta sidebar to use push-content pattern instead of overlay
- Resolved holographic background canvas blocking pointer events on sidebar

## Changes
**app/integrations/page.tsx**
- Replaced `CarmentaConcierge` (fixed overlay) with `CarmentaLayout` (flex push pattern)
- Matches AI Team page implementation - sidebar pushes content on desktop, routes to modal on mobile

**components/ui/holographic-background.tsx**  
- Added `pointer-events-none` to main holographic canvas
- Canvas was blocking clicks despite correct flex layout

## Root Cause
The layout was already pushing content correctly via flexbox (sidebar 380px, main at x: 380). The issue was the background canvas overlay intercepting pointer events. All other background layers had `pointer-events-none`, but the main canvas was missing it.

## Testing
Verified with Playwright that:
- Sidebar pushes content on desktop (flex layout working)
- Main content starts at x: 380 (sidebar width)
- Canvas now allows click-through to sidebar controls

Generated with Carmenta