### PR TITLE
Update all Phosphor Icons to use Icon suffix naming convention

### DIFF
--- a/app/ai-team/[slug]/[id]/edit-form.tsx
+++ b/app/ai-team/[slug]/[id]/edit-form.tsx
@@ -4,12 +4,12 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
 import {
-    ArrowLeft,
-    FloppyDisk,
-    Trash,
-    WarningCircle,
-    Play,
-    Sparkle,
+    ArrowLeftIcon,
+    FloppyDiskIcon,
+    TrashIcon,
+    WarningCircleIcon,
+    PlayIcon,
+    SparkleIcon,
 } from "@phosphor-icons/react";
 import * as Sentry from "@sentry/nextjs";
 
@@ -261,7 +261,7 @@ export function EditAutomationForm({ job }: EditAutomationFormProps) {
                         onClick={() => router.push("/ai-team")}
                         className="text-foreground/60 hover:text-foreground p-1 transition-colors"
                     >
-                        <ArrowLeft className="h-5 w-5" />
+                        <ArrowLeftIcon className="h-5 w-5" />
                     </button>
                     <div>
                         <h1 className="text-foreground text-xl font-medium">
@@ -280,7 +280,7 @@ export function EditAutomationForm({ job }: EditAutomationFormProps) {
                 >
                     {error && (
                         <div className="flex items-center gap-2 rounded-xl bg-red-500/10 p-4 text-red-500">
-                            <WarningCircle className="h-5 w-5" />
+                            <WarningCircleIcon className="h-5 w-5" />
                             <span>{error}</span>
                         </div>
                     )}
@@ -337,7 +337,7 @@ export function EditAutomationForm({ job }: EditAutomationFormProps) {
                             disabled={deleting}
                             className="flex items-center gap-2 rounded-xl px-4 py-2 text-red-500 transition-colors hover:bg-red-500/10 disabled:opacity-50"
                         >
-                            <Trash className="h-4 w-4" />
+                            <TrashIcon className="h-4 w-4" />
                             {deleting ? "Deleting..." : "Delete"}
                         </button>
 
@@ -359,9 +359,9 @@ export function EditAutomationForm({ job }: EditAutomationFormProps) {
                                 className="border-foreground/10 text-foreground hover:bg-foreground/5 flex items-center gap-2 rounded-xl border px-4 py-2 font-medium transition-colors disabled:opacity-50"
                             >
                                 {triggering ? (
-                                    <Sparkle className="h-4 w-4 animate-pulse" />
+                                    <SparkleIcon className="h-4 w-4 animate-pulse" />
                                 ) : (
-                                    <Play className="h-4 w-4" />
+                                    <PlayIcon className="h-4 w-4" />
                                 )}
                                 {triggering ? "Starting..." : "Try it"}
                             </button>
@@ -370,7 +370,7 @@ export function EditAutomationForm({ job }: EditAutomationFormProps) {
                                 disabled={saving || !hasChanges}
                                 className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center gap-2 rounded-xl px-6 py-2 font-medium transition-colors disabled:opacity-50"
                             >
-                                <FloppyDisk className="h-4 w-4" />
+                                <FloppyDiskIcon className="h-4 w-4" />
                                 {saving ? "Saving..." : "Save Changes"}
                             </button>
                         </div>
@@ -399,7 +399,7 @@ export function EditAutomationForm({ job }: EditAutomationFormProps) {
                             onClick={handleDelete}
                             className="flex items-center gap-2 rounded-xl bg-red-500 px-4 py-2 font-medium text-white transition-colors hover:bg-red-600"
                         >
-                            <Trash className="h-4 w-4" />
+                            <TrashIcon className="h-4 w-4" />
                             Delete
                         </button>
                     </DialogFooter>

--- a/app/ai-team/hire/page.tsx
+++ b/app/ai-team/hire/page.tsx
@@ -3,7 +3,12 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { Sparkle, ArrowLeft, Clock, CheckCircle } from "@phosphor-icons/react";
+import {
+    SparkleIcon,
+    ArrowLeftIcon,
+    ClockIcon,
+    CheckCircleIcon,
+} from "@phosphor-icons/react";
 import * as Sentry from "@sentry/nextjs";
 
 import { StandardPageLayout } from "@/components/layouts/standard-page-layout";
@@ -196,7 +201,7 @@ What can we help you with?`,
                             onClick={() => router.push("/ai-team")}
                             className="text-foreground/60 hover:text-foreground p-1 transition-colors"
                         >
-                            <ArrowLeft className="h-5 w-5" />
+                            <ArrowLeftIcon className="h-5 w-5" />
                         </button>
                         <div>
                             <h1 className="text-foreground text-xl font-medium">
@@ -258,7 +263,7 @@ What can we help you with?`,
                             className="border-foreground/10 bg-foreground/[0.01] w-80 flex-shrink-0 rounded-2xl border p-6"
                         >
                             <div className="mb-6 flex items-center gap-2">
-                                <CheckCircle className="text-primary h-5 w-5" />
+                                <CheckCircleIcon className="text-primary h-5 w-5" />
                                 <h2 className="text-foreground font-medium">
                                     Ready to Hire
                                 </h2>
@@ -279,7 +284,7 @@ What can we help you with?`,
                                         Schedule
                                     </p>
                                     <div className="text-foreground flex items-center gap-2">
-                                        <Clock className="h-4 w-4" />
+                                        <ClockIcon className="h-4 w-4" />
                                         <span>{playbook.schedule.displayText}</span>
                                     </div>
                                 </div>
@@ -323,12 +328,12 @@ What can we help you with?`,
                             >
                                 {isHiring ? (
                                     <>
-                                        <Sparkle className="h-4 w-4 animate-pulse" />
+                                        <SparkleIcon className="h-4 w-4 animate-pulse" />
                                         Setting up...
                                     </>
                                 ) : (
                                     <>
-                                        <CheckCircle className="h-4 w-4" />
+                                        <CheckCircleIcon className="h-4 w-4" />
                                         Hire This Team Member
                                     </>
                                 )}

--- a/app/ai-team/page.tsx
+++ b/app/ai-team/page.tsx
@@ -4,16 +4,16 @@ import { Suspense, useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import {
-    Users,
-    Sparkle,
-    Bell,
-    Lightning,
-    Gear,
-    Plus,
-    Clock,
-    WarningCircle,
-    CheckCircle,
-    Broadcast,
+    UsersIcon,
+    SparkleIcon,
+    BellIcon,
+    LightningIcon,
+    GearIcon,
+    PlusIcon,
+    ClockIcon,
+    WarningCircleIcon,
+    CheckCircleIcon,
+    BroadcastIcon,
 } from "@phosphor-icons/react";
 import * as Sentry from "@sentry/nextjs";
 
@@ -299,7 +299,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                         <div className="bg-primary/20 rounded-xl p-3">
-                            <Users className="text-primary h-6 w-6" />
+                            <UsersIcon className="text-primary h-6 w-6" />
                         </div>
                         <div>
                             <h1 className="text-foreground text-3xl font-light tracking-tight">
@@ -320,7 +320,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                             href="/ai-team/hire"
                             className="bg-primary text-primary-foreground hover:bg-primary/90 flex items-center gap-2 rounded-xl px-4 py-2 font-medium transition-colors"
                         >
-                            <Plus className="h-4 w-4" />
+                            <PlusIcon className="h-4 w-4" />
                             Hire
                         </Link>
                     </div>
@@ -330,7 +330,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
             {/* Success message banner */}
             {successMessage && (
                 <div className="flex items-center gap-2 rounded-xl bg-green-500/10 p-4 text-green-600 dark:text-green-400">
-                    <CheckCircle className="h-5 w-5" />
+                    <CheckCircleIcon className="h-5 w-5" />
                     <span className="font-medium">{successMessage}</span>
                 </div>
             )}
@@ -338,7 +338,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
             {loading ? (
                 <div className="flex items-center justify-center py-24">
                     <div className="flex flex-col items-center gap-4">
-                        <Sparkle className="text-primary h-8 w-8 animate-pulse" />
+                        <SparkleIcon className="text-primary h-8 w-8 animate-pulse" />
                         <p className="text-foreground/60">Loading your AI team...</p>
                     </div>
                 </div>
@@ -349,7 +349,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                         {/* Notifications banner */}
                         {unreadNotificationCount > 0 && (
                             <div className="bg-primary/10 text-primary flex items-center gap-3 rounded-xl p-4">
-                                <Bell className="h-5 w-5" />
+                                <BellIcon className="h-5 w-5" />
                                 <span className="font-medium">
                                     {unreadNotificationCount} item
                                     {unreadNotificationCount !== 1 ? "s" : ""} need
@@ -361,13 +361,13 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                         {/* What's Happening */}
                         <div className="space-y-4">
                             <h2 className="text-foreground flex items-center gap-2 text-xl font-medium">
-                                <Lightning className="text-primary h-5 w-5" />
+                                <LightningIcon className="text-primary h-5 w-5" />
                                 What's Happening
                             </h2>
 
                             {activities.length === 0 ? (
                                 <div className="border-foreground/5 bg-foreground/[0.02] flex flex-col items-center justify-center rounded-2xl border py-12 text-center">
-                                    <Clock className="text-foreground/30 mb-4 h-10 w-10" />
+                                    <ClockIcon className="text-foreground/30 mb-4 h-10 w-10" />
                                     <p className="text-foreground/60">
                                         No activity yet. Your automations will show up
                                         here.
@@ -382,11 +382,11 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                                             <div className="flex items-start justify-between gap-4">
                                                 <div className="flex items-start gap-3">
                                                     {activity.status === "completed" ? (
-                                                        <CheckCircle className="mt-0.5 h-5 w-5 text-green-500" />
+                                                        <CheckCircleIcon className="mt-0.5 h-5 w-5 text-green-500" />
                                                     ) : activity.status === "failed" ? (
-                                                        <WarningCircle className="mt-0.5 h-5 w-5 text-red-500" />
+                                                        <WarningCircleIcon className="mt-0.5 h-5 w-5 text-red-500" />
                                                     ) : (
-                                                        <Sparkle className="text-primary mt-0.5 h-5 w-5 animate-pulse" />
+                                                        <SparkleIcon className="text-primary mt-0.5 h-5 w-5 animate-pulse" />
                                                     )}
                                                     <div>
                                                         <p className="text-foreground font-medium">
@@ -414,7 +414,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                                                                 }}
                                                                 className="text-primary hover:bg-primary/10 flex items-center gap-1 rounded-lg px-2 py-1 text-xs font-medium transition-colors"
                                                             >
-                                                                <Broadcast className="h-3 w-3" />
+                                                                <BroadcastIcon className="h-3 w-3" />
                                                                 Tap In
                                                             </button>
                                                         )}
@@ -454,13 +454,13 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                     {/* Sidebar - Automations */}
                     <div className="space-y-4">
                         <h2 className="text-foreground flex items-center gap-2 text-xl font-medium">
-                            <Gear className="text-primary h-5 w-5" />
+                            <GearIcon className="text-primary h-5 w-5" />
                             Your Automations
                         </h2>
 
                         {automations.length === 0 ? (
                             <div className="border-foreground/5 bg-foreground/[0.02] flex flex-col items-center justify-center rounded-2xl border py-8 text-center">
-                                <Users className="text-foreground/30 mb-4 h-10 w-10" />
+                                <UsersIcon className="text-foreground/30 mb-4 h-10 w-10" />
                                 <p className="text-foreground/80 font-medium">
                                     No automations yet
                                 </p>
@@ -471,7 +471,7 @@ function AITeamContent({ refreshKey }: { refreshKey: number }) {
                                     href="/ai-team/hire"
                                     className="text-primary mt-4 flex items-center gap-1 text-sm font-medium hover:underline"
                                 >
-                                    <Plus className="h-4 w-4" />
+                                    <PlusIcon className="h-4 w-4" />
                                     Hire Now
                                 </Link>
                             </div>
@@ -560,7 +560,7 @@ export default function AITeamPage() {
                 <StandardPageLayout maxWidth="standard" contentClassName="py-12">
                     <div className="flex items-center justify-center py-24">
                         <div className="flex flex-col items-center gap-4">
-                            <Sparkle className="text-primary h-8 w-8 animate-pulse" />
+                            <SparkleIcon className="text-primary h-8 w-8 animate-pulse" />
                             <p className="text-foreground/60">
                                 Loading your AI team...
                             </p>

--- a/app/brand/icons/page.tsx
+++ b/app/brand/icons/page.tsx
@@ -14,169 +14,169 @@
 import { useState } from "react";
 import {
     // New Connection options
-    Plus,
-    PlusCircle,
-    ChatCircle,
-    Sparkle,
-    Lightning,
-    MagicWand,
-    Chats,
+    PlusIcon,
+    PlusCircleIcon,
+    ChatCircleIcon,
+    SparkleIcon,
+    LightningIcon,
+    MagicWandIcon,
+    ChatsIcon,
 
     // Save options
-    FloppyDisk,
-    CloudArrowUp,
-    Check,
-    CheckCircle,
-    DownloadSimple,
+    FloppyDiskIcon,
+    CloudArrowUpIcon,
+    CheckIcon,
+    CheckCircleIcon,
+    DownloadSimpleIcon,
 
     // User avatar options
-    UserCircle,
-    User,
-    UserFocus,
-    Person,
-    Smiley,
+    UserCircleIcon,
+    UserIcon,
+    UserFocusIcon,
+    PersonIcon,
+    SmileyIcon,
 
     // Heart options
-    Heart,
-    HeartStraight,
-    Heartbeat,
+    HeartIcon,
+    HeartStraightIcon,
+    HeartbeatIcon,
 
     // Home options
-    House,
-    HouseSimple,
-    Buildings,
-    Storefront,
+    HouseIcon,
+    HouseSimpleIcon,
+    BuildingsIcon,
+    StorefrontIcon,
 
     // Settings/Integrations options
-    Gear,
-    GearSix,
-    Sliders,
-    SlidersHorizontal,
-    Plug,
-    PlugsConnected,
-    Wrench,
+    GearIcon,
+    GearSixIcon,
+    SlidersIcon,
+    SlidersHorizontalIcon,
+    PlugIcon,
+    PlugsConnectedIcon,
+    WrenchIcon,
 
     // Send message options
-    PaperPlaneTilt,
-    PaperPlane,
-    ArrowRight,
-    ArrowCircleRight,
-    NavigationArrow,
+    PaperPlaneTiltIcon,
+    PaperPlaneIcon,
+    ArrowRightIcon,
+    ArrowCircleRightIcon,
+    NavigationArrowIcon,
 
     // Microphone options
-    Microphone,
-    Waveform,
-    SpeakerHigh,
-    Record,
+    MicrophoneIcon,
+    WaveformIcon,
+    SpeakerHighIcon,
+    RecordIcon,
 
     // Copy options
-    Copy,
-    CopySimple,
-    Clipboard,
-    ClipboardText,
+    CopyIcon,
+    CopySimpleIcon,
+    ClipboardIcon,
+    ClipboardTextIcon,
 
     // External link options
-    ArrowSquareOut,
-    ArrowUpRight,
-    Link,
-    LinkSimple,
+    ArrowSquareOutIcon,
+    ArrowUpRightIcon,
+    LinkIcon,
+    LinkSimpleIcon,
 
     // Menu/Navigation options
-    List,
-    DotsThree,
-    DotsThreeVertical,
-    CaretDown,
-    CaretRight,
+    ListIcon,
+    DotsThreeIcon,
+    DotsThreeVerticalIcon,
+    CaretDownIcon,
+    CaretRightIcon,
 
     // File/Document options
-    File,
-    FileText,
-    Files,
-    FolderOpen,
-    Folder,
+    FileIcon,
+    FileTextIcon,
+    FilesIcon,
+    FolderOpenIcon,
+    FolderIcon,
 
     // Search options
-    MagnifyingGlass,
-    Binoculars,
+    MagnifyingGlassIcon,
+    BinocularsIcon,
 
     // Close/Dismiss options
-    X,
-    XCircle,
+    XIcon,
+    XCircleIcon,
 
     // Warning/Error options
-    Warning,
-    WarningCircle,
-    Info,
+    WarningIcon,
+    WarningCircleIcon,
+    InfoIcon,
 
     // Refresh/Retry options
-    ArrowsClockwise,
-    ArrowClockwise,
-    ArrowCounterClockwise,
-    CircleNotch,
+    ArrowsClockwiseIcon,
+    ArrowClockwiseIcon,
+    ArrowCounterClockwiseIcon,
+    CircleNotchIcon,
 
     // Star/Favorite options
-    Star,
-    Bookmark,
-    BookmarkSimple,
+    StarIcon,
+    BookmarkIcon,
+    BookmarkSimpleIcon,
 
     // Trash/Delete options
-    Trash,
-    TrashSimple,
+    TrashIcon,
+    TrashSimpleIcon,
 
     // Edit options
-    PencilSimple,
-    Pencil,
-    NotePencil,
+    PencilSimpleIcon,
+    PencilIcon,
+    NotePencilIcon,
 
     // Calendar options
-    Calendar,
-    CalendarBlank,
-    Clock,
+    CalendarIcon,
+    CalendarBlankIcon,
+    ClockIcon,
 
     // Communication options
-    ChatTeardrop,
-    ChatText,
-    Chat,
-    Envelope,
-    EnvelopeSimple,
+    ChatTeardropIcon,
+    ChatTextIcon,
+    ChatIcon,
+    EnvelopeIcon,
+    EnvelopeSimpleIcon,
 
     // Code options
-    Code,
-    Terminal,
-    BracketsCurly,
-    CodeBlock,
+    CodeIcon,
+    TerminalIcon,
+    BracketsCurlyIcon,
+    CodeBlockIcon,
 
     // Brain/AI options
-    Brain,
-    Robot,
-    Atom,
-    Cpu,
+    BrainIcon,
+    RobotIcon,
+    AtomIcon,
+    CpuIcon,
 
     // Compass/Guide options
-    Compass,
-    Signpost,
-    Path,
-    MapTrifold,
+    CompassIcon,
+    SignpostIcon,
+    PathIcon,
+    MapTrifoldIcon,
 
     // Lock/Security options
-    Lock,
-    LockSimple,
-    Shield,
-    ShieldCheck,
+    LockIcon,
+    LockSimpleIcon,
+    ShieldIcon,
+    ShieldCheckIcon,
 
     // Play/Media options
-    Play,
-    Pause,
-    Stop,
+    PlayIcon,
+    PauseIcon,
+    StopIcon,
 
     // Expand/Collapse options
-    ArrowsOut,
-    ArrowsIn,
-    CaretDoubleDown,
-    CaretDoubleUp,
+    ArrowsOutIcon,
+    ArrowsInIcon,
+    CaretDoubleDownIcon,
+    CaretDoubleUpIcon,
 
     // GitHub option
-    GithubLogo,
+    GithubLogoIcon,
 } from "@phosphor-icons/react";
 import type { IconWeight } from "@phosphor-icons/react";
 
@@ -204,29 +204,29 @@ const categories: IconCategory[] = [
         description: "Starting a new conversation with Carmenta",
         semanticQuestion: "Is this about creation (+), conversation (chat), or magic?",
         options: [
-            { name: "Plus", icon: Plus, note: "Universal 'new' action" },
-            { name: "PlusCircle", icon: PlusCircle, note: "Softer, contained" },
+            { name: "Plus", icon: PlusIcon, note: "Universal 'new' action" },
+            { name: "PlusCircle", icon: PlusCircleIcon, note: "Softer, contained" },
             {
                 name: "ChatCircle",
-                icon: ChatCircle,
+                icon: ChatCircleIcon,
                 note: "Emphasizes conversation",
             },
             {
                 name: "Sparkle",
-                icon: Sparkle,
+                icon: SparkleIcon,
                 note: "Magic/AI feel, but might be overused",
             },
             {
                 name: "Lightning",
-                icon: Lightning,
+                icon: LightningIcon,
                 note: "Energy, speed",
             },
             {
                 name: "MagicWand",
-                icon: MagicWand,
+                icon: MagicWandIcon,
                 note: "Explicit magic metaphor",
             },
-            { name: "Chats", icon: Chats, note: "Multiple conversations" },
+            { name: "Chats", icon: ChatsIcon, note: "Multiple conversations" },
         ],
         recommendation:
             "Plus is clear and universal. ChatCircle with duotone could add warmth while conveying 'conversation'.",
@@ -238,13 +238,13 @@ const categories: IconCategory[] = [
         options: [
             {
                 name: "UserCircle",
-                icon: UserCircle,
+                icon: UserCircleIcon,
                 note: "Classic, works with duotone",
             },
-            { name: "User", icon: User, note: "Simpler, no container" },
-            { name: "UserFocus", icon: UserFocus, note: "More dynamic" },
-            { name: "Person", icon: Person, note: "Full body silhouette" },
-            { name: "Smiley", icon: Smiley, note: "Friendly, playful" },
+            { name: "User", icon: UserIcon, note: "Simpler, no container" },
+            { name: "UserFocus", icon: UserFocusIcon, note: "More dynamic" },
+            { name: "Person", icon: PersonIcon, note: "Full body silhouette" },
+            { name: "Smiley", icon: SmileyIcon, note: "Friendly, playful" },
         ],
         recommendation:
             "UserCircle with duotone - the inner fill adds life without being cartoonish.",
@@ -254,15 +254,15 @@ const categories: IconCategory[] = [
         description: "Heart-centered AI link",
         semanticQuestion: "Fill conveys love. Duotone adds dimension.",
         options: [
-            { name: "Heart", icon: Heart, note: "Classic heart shape" },
+            { name: "Heart", icon: HeartIcon, note: "Classic heart shape" },
             {
                 name: "HeartStraight",
-                icon: HeartStraight,
+                icon: HeartStraightIcon,
                 note: "More geometric",
             },
             {
                 name: "Heartbeat",
-                icon: Heartbeat,
+                icon: HeartbeatIcon,
                 note: "Living, dynamic",
             },
         ],
@@ -274,14 +274,14 @@ const categories: IconCategory[] = [
         description: "Navigation to home/landing",
         semanticQuestion: "House is literal. Could be more abstract?",
         options: [
-            { name: "House", icon: House, note: "Classic home" },
-            { name: "HouseSimple", icon: HouseSimple, note: "Cleaner lines" },
+            { name: "House", icon: HouseIcon, note: "Classic home" },
+            { name: "HouseSimple", icon: HouseSimpleIcon, note: "Cleaner lines" },
             {
                 name: "Buildings",
-                icon: Buildings,
+                icon: BuildingsIcon,
                 note: "More urban/professional",
             },
-            { name: "Storefront", icon: Storefront, note: "Inviting entry" },
+            { name: "Storefront", icon: StorefrontIcon, note: "Inviting entry" },
         ],
         recommendation: "House with regular weight - familiar and clear.",
     },
@@ -292,19 +292,19 @@ const categories: IconCategory[] = [
         options: [
             {
                 name: "PaperPlaneTilt",
-                icon: PaperPlaneTilt,
+                icon: PaperPlaneTiltIcon,
                 note: "Dynamic, taking flight",
             },
-            { name: "PaperPlane", icon: PaperPlane, note: "More static" },
-            { name: "ArrowRight", icon: ArrowRight, note: "Pure direction" },
+            { name: "PaperPlane", icon: PaperPlaneIcon, note: "More static" },
+            { name: "ArrowRight", icon: ArrowRightIcon, note: "Pure direction" },
             {
                 name: "ArrowCircleRight",
-                icon: ArrowCircleRight,
+                icon: ArrowCircleRightIcon,
                 note: "Contained arrow",
             },
             {
                 name: "NavigationArrow",
-                icon: NavigationArrow,
+                icon: NavigationArrowIcon,
                 note: "GPS/direction feel",
             },
         ],
@@ -316,13 +316,13 @@ const categories: IconCategory[] = [
         description: "Microphone button for voice mode",
         semanticQuestion: "Recording vs. speaking vs. audio?",
         options: [
-            { name: "Microphone", icon: Microphone, note: "Universal voice" },
+            { name: "Microphone", icon: MicrophoneIcon, note: "Universal voice" },
             {
                 name: "Waveform",
-                icon: Waveform,
+                icon: WaveformIcon,
                 note: "Audio/sound visualization",
             },
-            { name: "Record", icon: Record, note: "Recording action" },
+            { name: "Record", icon: RecordIcon, note: "Recording action" },
         ],
         recommendation:
             "Microphone - universally understood. Could animate to Waveform when active.",
@@ -332,12 +332,12 @@ const categories: IconCategory[] = [
         description: "Copy button on code blocks, messages",
         semanticQuestion: "Clipboard metaphor vs. document duplication?",
         options: [
-            { name: "Copy", icon: Copy, note: "Two overlapping documents" },
-            { name: "CopySimple", icon: CopySimple, note: "Cleaner version" },
-            { name: "Clipboard", icon: Clipboard, note: "Physical clipboard" },
+            { name: "Copy", icon: CopyIcon, note: "Two overlapping documents" },
+            { name: "CopySimple", icon: CopySimpleIcon, note: "Cleaner version" },
+            { name: "Clipboard", icon: ClipboardIcon, note: "Physical clipboard" },
             {
                 name: "ClipboardText",
-                icon: ClipboardText,
+                icon: ClipboardTextIcon,
                 note: "Clipboard with content",
             },
         ],
@@ -351,12 +351,12 @@ const categories: IconCategory[] = [
         options: [
             {
                 name: "ArrowSquareOut",
-                icon: ArrowSquareOut,
+                icon: ArrowSquareOutIcon,
                 note: "Arrow leaving box",
             },
-            { name: "ArrowUpRight", icon: ArrowUpRight, note: "Directional" },
-            { name: "Link", icon: Link, note: "Chain link" },
-            { name: "LinkSimple", icon: LinkSimple, note: "Simplified link" },
+            { name: "ArrowUpRight", icon: ArrowUpRightIcon, note: "Directional" },
+            { name: "Link", icon: LinkIcon, note: "Chain link" },
+            { name: "LinkSimple", icon: LinkSimpleIcon, note: "Simplified link" },
         ],
         recommendation: "ArrowSquareOut - clearly indicates 'leaving this context'.",
     },
@@ -366,18 +366,18 @@ const categories: IconCategory[] = [
         semanticQuestion:
             "Mechanical (gear) vs. adjustment (sliders) vs. connection (plug)?",
         options: [
-            { name: "Gear", icon: Gear, note: "Classic settings" },
-            { name: "GearSix", icon: GearSix, note: "More detail" },
-            { name: "Sliders", icon: Sliders, note: "Adjustment metaphor" },
+            { name: "Gear", icon: GearIcon, note: "Classic settings" },
+            { name: "GearSix", icon: GearSixIcon, note: "More detail" },
+            { name: "Sliders", icon: SlidersIcon, note: "Adjustment metaphor" },
             {
                 name: "SlidersHorizontal",
-                icon: SlidersHorizontal,
+                icon: SlidersHorizontalIcon,
                 note: "Horizontal variant",
             },
-            { name: "Plug", icon: Plug, note: "Connection focus" },
+            { name: "Plug", icon: PlugIcon, note: "Connection focus" },
             {
                 name: "PlugsConnected",
-                icon: PlugsConnected,
+                icon: PlugsConnectedIcon,
                 note: "Active connection",
             },
         ],
@@ -391,18 +391,18 @@ const categories: IconCategory[] = [
         options: [
             {
                 name: "Compass",
-                icon: Compass,
+                icon: CompassIcon,
                 note: "Finding direction",
             },
             {
                 name: "Signpost",
-                icon: Signpost,
+                icon: SignpostIcon,
                 note: "Showing the way",
             },
-            { name: "Path", icon: Path, note: "Journey metaphor" },
+            { name: "Path", icon: PathIcon, note: "Journey metaphor" },
             {
                 name: "MapTrifold",
-                icon: MapTrifold,
+                icon: MapTrifoldIcon,
                 note: "Overview/planning",
             },
         ],
@@ -413,10 +413,10 @@ const categories: IconCategory[] = [
         description: "How We Build, code mode",
         semanticQuestion: "Brackets vs. terminal vs. abstract?",
         options: [
-            { name: "Code", icon: Code, note: "Angle brackets < />" },
-            { name: "Terminal", icon: Terminal, note: "Command line" },
-            { name: "BracketsCurly", icon: BracketsCurly, note: "{ } focus" },
-            { name: "CodeBlock", icon: CodeBlock, note: "Block of code" },
+            { name: "Code", icon: CodeIcon, note: "Angle brackets < />" },
+            { name: "Terminal", icon: TerminalIcon, note: "Command line" },
+            { name: "BracketsCurly", icon: BracketsCurlyIcon, note: "{ } focus" },
+            { name: "CodeBlock", icon: CodeBlockIcon, note: "Block of code" },
         ],
         recommendation: "Code - universally recognized for development.",
     },
@@ -425,10 +425,10 @@ const categories: IconCategory[] = [
         description: "Autonomous agents working for you",
         semanticQuestion: "Team (people) vs. AI (robot/brain) vs. capability?",
         options: [
-            { name: "Robot", icon: Robot, note: "AI/automation feel" },
-            { name: "Brain", icon: Brain, note: "Intelligence" },
-            { name: "Atom", icon: Atom, note: "Science/capability" },
-            { name: "Cpu", icon: Cpu, note: "Processing/compute" },
+            { name: "Robot", icon: RobotIcon, note: "AI/automation feel" },
+            { name: "Brain", icon: BrainIcon, note: "Intelligence" },
+            { name: "Atom", icon: AtomIcon, note: "Science/capability" },
+            { name: "Cpu", icon: CpuIcon, note: "Processing/compute" },
         ],
         recommendation:
             "Tricky - Robot might feel cold. Brain is too biological. Consider keeping Users icon to emphasize 'team' over 'AI'.",
@@ -440,15 +440,15 @@ const categories: IconCategory[] = [
         options: [
             {
                 name: "ChatTeardrop",
-                icon: ChatTeardrop,
+                icon: ChatTeardropIcon,
                 note: "Softer, friendly",
             },
-            { name: "ChatText", icon: ChatText, note: "With text lines" },
-            { name: "Chat", icon: Chat, note: "Simple bubble" },
-            { name: "Envelope", icon: Envelope, note: "Email specific" },
+            { name: "ChatText", icon: ChatTextIcon, note: "With text lines" },
+            { name: "Chat", icon: ChatIcon, note: "Simple bubble" },
+            { name: "Envelope", icon: EnvelopeIcon, note: "Email specific" },
             {
                 name: "EnvelopeSimple",
-                icon: EnvelopeSimple,
+                icon: EnvelopeSimpleIcon,
                 note: "Cleaner envelope",
             },
         ],
@@ -460,10 +460,10 @@ const categories: IconCategory[] = [
         description: "Saving content or confirming action",
         semanticQuestion: "Disk (legacy) vs. cloud (modern) vs. check (done)?",
         options: [
-            { name: "FloppyDisk", icon: FloppyDisk, note: "Classic save icon" },
-            { name: "CloudArrowUp", icon: CloudArrowUp, note: "Cloud save" },
-            { name: "Check", icon: Check, note: "Confirmation" },
-            { name: "CheckCircle", icon: CheckCircle, note: "Complete/success" },
+            { name: "FloppyDisk", icon: FloppyDiskIcon, note: "Classic save icon" },
+            { name: "CloudArrowUp", icon: CloudArrowUpIcon, note: "Cloud save" },
+            { name: "Check", icon: CheckIcon, note: "Confirmation" },
+            { name: "CheckCircle", icon: CheckCircleIcon, note: "Complete/success" },
         ],
         recommendation:
             "Check for confirmation, FloppyDisk only if explicitly 'saving'. Consider auto-save to eliminate the icon entirely.",
@@ -475,18 +475,18 @@ const categories: IconCategory[] = [
         options: [
             {
                 name: "CircleNotch",
-                icon: CircleNotch,
+                icon: CircleNotchIcon,
                 note: "Animatable spinner",
             },
-            { name: "ArrowsClockwise", icon: ArrowsClockwise, note: "Refresh" },
+            { name: "ArrowsClockwise", icon: ArrowsClockwiseIcon, note: "Refresh" },
             {
                 name: "ArrowClockwise",
-                icon: ArrowClockwise,
+                icon: ArrowClockwiseIcon,
                 note: "Single direction",
             },
             {
                 name: "ArrowCounterClockwise",
-                icon: ArrowCounterClockwise,
+                icon: ArrowCounterClockwiseIcon,
                 note: "Undo",
             },
         ],
@@ -498,8 +498,8 @@ const categories: IconCategory[] = [
         description: "Destructive actions",
         semanticQuestion: "Trash can is universal. Should look serious.",
         options: [
-            { name: "Trash", icon: Trash, note: "Detailed trash can" },
-            { name: "TrashSimple", icon: TrashSimple, note: "Simpler version" },
+            { name: "Trash", icon: TrashIcon, note: "Detailed trash can" },
+            { name: "TrashSimple", icon: TrashSimpleIcon, note: "Simpler version" },
         ],
         recommendation: "Trash - the detail helps convey the seriousness.",
     },
@@ -508,8 +508,8 @@ const categories: IconCategory[] = [
         description: "Closing modals, dismissing notifications",
         semanticQuestion: "X is universal. Circle variant is softer.",
         options: [
-            { name: "X", icon: X, note: "Universal close" },
-            { name: "XCircle", icon: XCircle, note: "Contained, softer" },
+            { name: "X", icon: XIcon, note: "Universal close" },
+            { name: "XCircle", icon: XCircleIcon, note: "Contained, softer" },
         ],
         recommendation: "X for inline close, XCircle for dismissing errors.",
     },
@@ -518,9 +518,9 @@ const categories: IconCategory[] = [
         description: "Alerts and error states",
         semanticQuestion: "Triangle is serious. Circle is informational.",
         options: [
-            { name: "Warning", icon: Warning, note: "Triangle alert" },
-            { name: "WarningCircle", icon: WarningCircle, note: "Circle alert" },
-            { name: "Info", icon: Info, note: "Informational" },
+            { name: "Warning", icon: WarningIcon, note: "Triangle alert" },
+            { name: "WarningCircle", icon: WarningCircleIcon, note: "Circle alert" },
+            { name: "Info", icon: InfoIcon, note: "Informational" },
         ],
         recommendation:
             "Warning for errors/serious. Info for tips. WarningCircle for moderate alerts.",
@@ -536,12 +536,12 @@ function IconGrid({
 }) {
     return (
         <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-            {icons.map(({ name, icon: Icon, note }) => (
+            {icons.map(({ name, icon: IconIcon, note }) => (
                 <div
                     key={name}
                     className="bg-card hover:bg-card/80 flex flex-col items-center gap-2 rounded-xl border p-4 transition-colors"
                 >
-                    <Icon weight={selectedWeight} className="h-8 w-8" />
+                    <IconIcon weight={selectedWeight} className="h-8 w-8" />
                     <span className="text-sm font-medium">{name}</span>
                     {note && (
                         <span className="text-muted-foreground text-center text-xs">

--- a/app/code/[repo]/page.tsx
+++ b/app/code/[repo]/page.tsx
@@ -12,7 +12,11 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowLeft, CircleNotch, FolderSimple } from "@phosphor-icons/react";
+import {
+    ArrowLeftIcon,
+    CircleNotchIcon,
+    FolderSimpleIcon,
+} from "@phosphor-icons/react";
 import Image from "next/image";
 
 import { SessionPicker, type CodeSession } from "@/components/code/session-picker";
@@ -68,11 +72,11 @@ export default function CodeProjectPage() {
                         className="text-muted-foreground hover:bg-muted hover:text-foreground rounded-lg p-2 transition-colors"
                         aria-label="Back to projects"
                     >
-                        <ArrowLeft className="h-5 w-5" weight="regular" />
+                        <ArrowLeftIcon className="h-5 w-5" weight="regular" />
                     </button>
                     <div className="flex items-center gap-3">
                         <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-100 dark:bg-purple-900/30">
-                            <FolderSimple className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+                            <FolderSimpleIcon className="h-5 w-5 text-purple-600 dark:text-purple-400" />
                         </div>
                         <div>
                             <h1 className="text-foreground font-semibold">
@@ -93,7 +97,7 @@ export default function CodeProjectPage() {
                             animate={{ opacity: 1 }}
                             className="flex flex-col items-center gap-3"
                         >
-                            <CircleNotch className="h-8 w-8 animate-spin text-purple-600" />
+                            <CircleNotchIcon className="h-8 w-8 animate-spin text-purple-600" />
                             <p className="text-muted-foreground">Loading sessions...</p>
                         </motion.div>
                     ) : error ? (

--- a/app/code/page.tsx
+++ b/app/code/page.tsx
@@ -16,7 +16,11 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { FolderSimple, ArrowRight, CircleNotch } from "@phosphor-icons/react";
+import {
+    FolderSimpleIcon,
+    ArrowRightIcon,
+    CircleNotchIcon,
+} from "@phosphor-icons/react";
 
 import Image from "next/image";
 
@@ -102,7 +106,7 @@ export default function CodePage() {
                                 animate={{ opacity: 1, height: "auto" }}
                             >
                                 <div className="flex items-start gap-3">
-                                    <FolderSimple className="mt-0.5 h-5 w-5 text-purple-600 dark:text-purple-400" />
+                                    <FolderSimpleIcon className="mt-0.5 h-5 w-5 text-purple-600 dark:text-purple-400" />
                                     <div className="min-w-0 flex-1">
                                         <p className="font-medium text-purple-900 dark:text-purple-100">
                                             {selectedProject.name}
@@ -134,13 +138,13 @@ export default function CodePage() {
                     >
                         {isNavigating ? (
                             <>
-                                <CircleNotch className="h-5 w-5 animate-spin" />
+                                <CircleNotchIcon className="h-5 w-5 animate-spin" />
                                 Starting session...
                             </>
                         ) : (
                             <>
                                 Start Coding
-                                <ArrowRight className="h-5 w-5" />
+                                <ArrowRightIcon className="h-5 w-5" />
                             </>
                         )}
                     </button>

--- a/app/connect/[service]/page.tsx
+++ b/app/connect/[service]/page.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 import * as Sentry from "@sentry/nextjs";
 import { logger } from "@/lib/client-logger";
 import { getServiceById } from "@/lib/integrations/services";
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 import { HolographicBackground } from "@/components/ui/holographic-background";
 
 export default function ConnectServicePage() {
@@ -97,7 +97,7 @@ export default function ConnectServicePage() {
             <div className="z-content relative flex min-h-screen items-center justify-center">
                 <div className="glass-card mx-auto max-w-md p-8 text-center">
                     <div className="mb-4 flex justify-center">
-                        <Sparkle className="text-primary h-12 w-12 animate-pulse" />
+                        <SparkleIcon className="text-primary h-12 w-12 animate-pulse" />
                     </div>
                     <h1 className="text-foreground mb-2 text-2xl font-semibold">
                         Connecting {serviceName}...

--- a/app/integrations/mcp/page.tsx
+++ b/app/integrations/mcp/page.tsx
@@ -16,19 +16,19 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import Link from "next/link";
 import {
-    Plug,
-    X,
-    CaretDown,
-    CaretUp,
-    Spinner,
-    Check,
-    Warning,
-    ArrowLeft,
-    Trash,
-    Power,
-    CircleNotch,
-    PlugsConnected,
-    Plugs,
+    PlugIcon,
+    XIcon,
+    CaretDownIcon,
+    CaretUpIcon,
+    SpinnerIcon,
+    CheckIcon,
+    WarningIcon,
+    ArrowLeftIcon,
+    TrashIcon,
+    PowerIcon,
+    CircleNotchIcon,
+    PlugsConnectedIcon,
+    PlugsIcon,
 } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "framer-motion";
 import * as Sentry from "@sentry/nextjs";
@@ -67,50 +67,50 @@ interface ToolPart {
 }
 
 function getToolDisplay(toolName: string): {
-    icon: typeof Plug;
+    icon: typeof PlugIcon;
     label: string;
     verb: string;
 } {
     switch (toolName) {
         case "parseConfig":
             return {
-                icon: Plug,
+                icon: PlugIcon,
                 label: "Parse",
                 verb: "Parsing configuration",
             };
         case "testConnection":
             return {
-                icon: PlugsConnected,
+                icon: PlugsConnectedIcon,
                 label: "Test",
                 verb: "Testing connection",
             };
         case "saveServer":
             return {
-                icon: Check,
+                icon: CheckIcon,
                 label: "Save",
                 verb: "Saving server",
             };
         case "listServers":
             return {
-                icon: Plugs,
+                icon: PlugsIcon,
                 label: "List",
                 verb: "Listing servers",
             };
         case "removeServer":
             return {
-                icon: Trash,
+                icon: TrashIcon,
                 label: "Remove",
                 verb: "Removing server",
             };
         case "updateServer":
             return {
-                icon: Power,
+                icon: PowerIcon,
                 label: "Update",
                 verb: "Updating server",
             };
         default:
             return {
-                icon: Plug,
+                icon: PlugIcon,
                 label: "Action",
                 verb: "Processing",
             };
@@ -149,11 +149,13 @@ function McpToolActivityItem({ part }: { part: ToolPart }) {
                 )}
             >
                 {!isComplete && !hasError && (
-                    <Spinner className="h-3 w-3 animate-spin" />
+                    <SpinnerIcon className="h-3 w-3 animate-spin" />
                 )}
-                {isComplete && success && <Check className="h-3 w-3" weight="bold" />}
-                {isComplete && !success && <Warning className="h-3 w-3" />}
-                {hasError && <Warning className="h-3 w-3" />}
+                {isComplete && success && (
+                    <CheckIcon className="h-3 w-3" weight="bold" />
+                )}
+                {isComplete && !success && <WarningIcon className="h-3 w-3" />}
+                {hasError && <WarningIcon className="h-3 w-3" />}
             </span>
 
             <Icon
@@ -345,7 +347,7 @@ function McpConfigChat({ onConfigChange, className }: McpConfigChatProps) {
         >
             <form onSubmit={handleSubmit} className="flex items-center gap-3 p-4">
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10">
-                    <Plug className="h-5 w-5 text-emerald-500" weight="duotone" />
+                    <PlugIcon className="h-5 w-5 text-emerald-500" weight="duotone" />
                 </div>
 
                 <input
@@ -364,10 +366,10 @@ function McpConfigChat({ onConfigChange, className }: McpConfigChatProps) {
                 />
 
                 {isLoading && (
-                    <Spinner className="h-4 w-4 animate-spin text-emerald-500" />
+                    <SpinnerIcon className="h-4 w-4 animate-spin text-emerald-500" />
                 )}
                 {isComplete && (
-                    <Check className="h-4 w-4 text-green-500" weight="bold" />
+                    <CheckIcon className="h-4 w-4 text-green-500" weight="bold" />
                 )}
 
                 {hasResponse && !isLoading && (
@@ -377,9 +379,9 @@ function McpConfigChat({ onConfigChange, className }: McpConfigChatProps) {
                         className="text-foreground/40 hover:text-foreground/60 transition-colors"
                     >
                         {isExpanded ? (
-                            <CaretUp className="h-4 w-4" />
+                            <CaretUpIcon className="h-4 w-4" />
                         ) : (
-                            <CaretDown className="h-4 w-4" />
+                            <CaretDownIcon className="h-4 w-4" />
                         )}
                     </button>
                 )}
@@ -390,7 +392,7 @@ function McpConfigChat({ onConfigChange, className }: McpConfigChatProps) {
                         onClick={handleDismiss}
                         className="text-foreground/40 hover:text-foreground/60 transition-colors"
                     >
-                        <X className="h-4 w-4" />
+                        <XIcon className="h-4 w-4" />
                     </button>
                 )}
             </form>
@@ -427,7 +429,7 @@ function McpConfigChat({ onConfigChange, className }: McpConfigChatProps) {
 
                             {isLoading && !responseText && toolParts.length === 0 && (
                                 <p className="text-foreground/50 flex items-center gap-2 text-sm">
-                                    <Spinner className="h-3 w-3 animate-spin" />
+                                    <SpinnerIcon className="h-3 w-3 animate-spin" />
                                     Connecting...
                                 </p>
                             )}
@@ -485,7 +487,7 @@ function ServerList({ servers, loading, className }: ServerListProps) {
                     className
                 )}
             >
-                <CircleNotch className="text-foreground/40 h-6 w-6 animate-spin" />
+                <CircleNotchIcon className="text-foreground/40 h-6 w-6 animate-spin" />
                 <p className="text-foreground/50 mt-2 text-sm">Loading servers...</p>
             </div>
         );
@@ -499,7 +501,7 @@ function ServerList({ servers, loading, className }: ServerListProps) {
                     className
                 )}
             >
-                <Plugs className="text-foreground/20 mx-auto h-10 w-10" />
+                <PlugsIcon className="text-foreground/20 mx-auto h-10 w-10" />
                 <h3 className="text-foreground/60 mt-3 text-sm font-medium">
                     No servers connected
                 </h3>
@@ -590,13 +592,13 @@ export default function McpConfigPage() {
                     href="/integrations"
                     className="text-foreground/50 hover:text-foreground/70 inline-flex items-center gap-1 text-sm transition-colors"
                 >
-                    <ArrowLeft className="h-4 w-4" />
+                    <ArrowLeftIcon className="h-4 w-4" />
                     Back to Integrations
                 </Link>
 
                 <div className="flex items-center gap-3">
                     <div className="rounded-xl bg-emerald-500/20 p-3">
-                        <Plug className="h-6 w-6 text-emerald-500" />
+                        <PlugIcon className="h-6 w-6 text-emerald-500" />
                     </div>
                     <div>
                         <h1 className="text-foreground text-3xl font-light tracking-tight">

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -3,12 +3,12 @@
 import { Suspense, useState, useEffect, useCallback } from "react";
 import { useSearchParams } from "next/navigation";
 import {
-    Plug,
-    Sparkle,
-    CheckCircle,
-    XCircle,
-    X,
-    ArrowCounterClockwise,
+    PlugIcon,
+    SparkleIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+    XIcon,
+    ArrowCounterClockwiseIcon,
 } from "@phosphor-icons/react";
 import * as Sentry from "@sentry/nextjs";
 
@@ -448,7 +448,7 @@ function IntegrationsContent({ refreshKey }: { refreshKey: number }) {
                 <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
                         <div className="bg-primary/20 rounded-xl p-3">
-                            <Plug className="text-primary h-6 w-6" />
+                            <PlugIcon className="text-primary h-6 w-6" />
                         </div>
                         <div>
                             <h1 className="text-foreground text-3xl font-light tracking-tight">
@@ -480,9 +480,9 @@ function IntegrationsContent({ refreshKey }: { refreshKey: number }) {
                 >
                     <div className="flex items-center gap-3">
                         {globalMessage.type === "success" ? (
-                            <CheckCircle className="h-5 w-5 flex-shrink-0" />
+                            <CheckCircleIcon className="h-5 w-5 flex-shrink-0" />
                         ) : (
-                            <XCircle className="h-5 w-5 flex-shrink-0" />
+                            <XCircleIcon className="h-5 w-5 flex-shrink-0" />
                         )}
                         <span className="text-sm font-medium">
                             {globalMessage.text}
@@ -493,7 +493,7 @@ function IntegrationsContent({ refreshKey }: { refreshKey: number }) {
                         className="hover:bg-foreground/10 rounded-lg p-1"
                         aria-label="Dismiss message"
                     >
-                        <X className="h-4 w-4" />
+                        <XIcon className="h-4 w-4" />
                     </button>
                 </div>
             )}
@@ -502,7 +502,7 @@ function IntegrationsContent({ refreshKey }: { refreshKey: number }) {
             {abandonedService && !globalMessage && (
                 <div className="flex items-center justify-between gap-3 rounded-xl bg-amber-500/10 p-4 text-amber-700 dark:text-amber-400">
                     <div className="flex items-center gap-3">
-                        <ArrowCounterClockwise className="h-5 w-5 flex-shrink-0" />
+                        <ArrowCounterClockwiseIcon className="h-5 w-5 flex-shrink-0" />
                         <span className="text-sm font-medium">
                             Didn't finish connecting {abandonedServiceName}?
                         </span>
@@ -519,7 +519,7 @@ function IntegrationsContent({ refreshKey }: { refreshKey: number }) {
                             className="hover:bg-foreground/10 rounded-lg p-1"
                             aria-label="Dismiss"
                         >
-                            <X className="h-4 w-4" />
+                            <XIcon className="h-4 w-4" />
                         </button>
                     </div>
                 </div>
@@ -528,13 +528,13 @@ function IntegrationsContent({ refreshKey }: { refreshKey: number }) {
             {loading ? (
                 <div className="flex items-center justify-center py-24">
                     <div className="flex flex-col items-center gap-4">
-                        <Sparkle className="text-primary h-8 w-8 animate-pulse" />
+                        <SparkleIcon className="text-primary h-8 w-8 animate-pulse" />
                         <p className="text-foreground/60">Loading integrations...</p>
                     </div>
                 </div>
             ) : services.length === 0 ? (
                 <div className="border-foreground/5 bg-foreground/[0.02] flex flex-col items-center justify-center rounded-2xl border py-16 text-center">
-                    <Plug className="text-foreground/30 mb-4 h-12 w-12" />
+                    <PlugIcon className="text-foreground/30 mb-4 h-12 w-12" />
                     <h3 className="text-foreground/80 text-lg font-medium">
                         No connections yet
                     </h3>
@@ -667,7 +667,7 @@ export default function IntegrationsPage() {
                 <StandardPageLayout maxWidth="standard" contentClassName="py-12">
                     <div className="flex items-center justify-center py-24">
                         <div className="flex flex-col items-center gap-4">
-                            <Sparkle className="text-primary h-8 w-8 animate-pulse" />
+                            <SparkleIcon className="text-primary h-8 w-8 animate-pulse" />
                             <p className="text-foreground/60">
                                 Loading integrations...
                             </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import Link from "next/link";
-import { ArrowRight, CaretLeft, CaretRight } from "@phosphor-icons/react";
+import { ArrowRightIcon, CaretLeftIcon, CaretRightIcon } from "@phosphor-icons/react";
 import { motion, useReducedMotion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { Footer } from "@/components/footer";
@@ -220,7 +220,7 @@ export default function HomePage() {
                             className="hover:ring-primary/40 focus:ring-primary/40 mt-10 inline-flex items-center gap-2 rounded-full bg-gradient-to-br from-purple-500 via-cyan-500 to-pink-500 px-8 py-3.5 text-lg font-medium text-white shadow-xl transition-all hover:scale-105 hover:shadow-2xl hover:ring-[3px] focus:scale-105 focus:shadow-2xl focus:ring-[3px] focus:outline-none active:translate-y-0.5 active:shadow-sm"
                         >
                             Connect to AI
-                            <ArrowRight className="h-5 w-5" />
+                            <ArrowRightIcon className="h-5 w-5" />
                         </Link>
                     </motion.div>
 
@@ -294,7 +294,7 @@ export default function HomePage() {
                                 className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/70 rounded-full p-2 transition-all hover:scale-110"
                                 aria-label="Previous slide"
                             >
-                                <CaretLeft className="h-4 w-4" />
+                                <CaretLeftIcon className="h-4 w-4" />
                             </button>
                             <div className="flex items-center gap-2">
                                 {shuffledFeatures.map((_, i) => (
@@ -316,7 +316,7 @@ export default function HomePage() {
                                 className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/70 rounded-full p-2 transition-all hover:scale-110"
                                 aria-label="Next slide"
                             >
-                                <CaretRight className="h-4 w-4" />
+                                <CaretRightIcon className="h-4 w-4" />
                             </button>
                         </div>
                     </motion.div>

--- a/components/ai-team/job-progress-viewer.tsx
+++ b/components/ai-team/job-progress-viewer.tsx
@@ -11,7 +11,12 @@
  */
 
 import { useEffect, useState, useRef, useCallback } from "react";
-import { Sparkle, WarningCircle, CheckCircle, X } from "@phosphor-icons/react";
+import {
+    SparkleIcon,
+    WarningCircleIcon,
+    CheckCircleIcon,
+    XIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { logger } from "@/lib/client-logger";
@@ -153,13 +158,13 @@ export function JobProgressViewer({
                 <div className="flex items-center gap-3">
                     <div className="bg-primary/20 rounded-lg p-2">
                         {status === "streaming" ? (
-                            <Sparkle className="text-primary h-4 w-4 animate-pulse" />
+                            <SparkleIcon className="text-primary h-4 w-4 animate-pulse" />
                         ) : status === "completed" ? (
-                            <CheckCircle className="h-4 w-4 text-green-500" />
+                            <CheckCircleIcon className="h-4 w-4 text-green-500" />
                         ) : status === "error" ? (
-                            <WarningCircle className="h-4 w-4 text-red-500" />
+                            <WarningCircleIcon className="h-4 w-4 text-red-500" />
                         ) : (
-                            <Sparkle className="text-foreground/50 h-4 w-4" />
+                            <SparkleIcon className="text-foreground/50 h-4 w-4" />
                         )}
                     </div>
                     <div>
@@ -177,7 +182,7 @@ export function JobProgressViewer({
                     onClick={onClose}
                     className="text-foreground/60 hover:text-foreground rounded-lg p-2 transition-colors"
                 >
-                    <X className="h-5 w-5" />
+                    <XIcon className="h-5 w-5" />
                 </button>
             </div>
 
@@ -186,7 +191,7 @@ export function JobProgressViewer({
                 {/* No stream state */}
                 {status === "no-stream" && (
                     <div className="flex flex-col items-center justify-center py-12 text-center">
-                        <Sparkle className="text-foreground/30 mb-4 h-10 w-10" />
+                        <SparkleIcon className="text-foreground/30 mb-4 h-10 w-10" />
                         <p className="text-foreground/70">
                             This job isn't currently running.
                         </p>
@@ -229,7 +234,7 @@ export function JobProgressViewer({
                             !textContent &&
                             activeTransients.length === 0 && (
                                 <div className="flex items-center gap-2 py-8">
-                                    <Sparkle className="text-primary h-4 w-4 animate-pulse" />
+                                    <SparkleIcon className="text-primary h-4 w-4 animate-pulse" />
                                     <span className="text-foreground/60 text-sm">
                                         Waiting for output...
                                     </span>
@@ -241,7 +246,7 @@ export function JobProgressViewer({
                 {/* Error state */}
                 {status === "error" && (
                     <div className="flex flex-col items-center justify-center py-12 text-center">
-                        <WarningCircle className="mb-4 h-10 w-10 text-red-500" />
+                        <WarningCircleIcon className="mb-4 h-10 w-10 text-red-500" />
                         <p className="text-foreground/70">{error}</p>
                         <p className="text-foreground/50 mt-1 text-sm">
                             The connection to the job stream was lost.

--- a/components/benchmarks/category-breakdown.tsx
+++ b/components/benchmarks/category-breakdown.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { CaretDown, CaretUp } from "@phosphor-icons/react";
+import { CaretDownIcon, CaretUpIcon } from "@phosphor-icons/react";
 
 import type { CategoryScore, QueryResult } from "@/lib/benchmarks/types";
 import {
@@ -61,9 +61,9 @@ export function CategoryBreakdown({
                         >
                             <div className="flex items-center gap-3">
                                 {isExpanded ? (
-                                    <CaretUp className="text-foreground/40 h-4 w-4" />
+                                    <CaretUpIcon className="text-foreground/40 h-4 w-4" />
                                 ) : (
-                                    <CaretDown className="text-foreground/40 h-4 w-4" />
+                                    <CaretDownIcon className="text-foreground/40 h-4 w-4" />
                                 )}
                                 <div>
                                     <span className="text-foreground font-medium">

--- a/components/benchmarks/competitor-leaderboard.tsx
+++ b/components/benchmarks/competitor-leaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, Fragment } from "react";
-import { CaretDown, CaretUp } from "@phosphor-icons/react";
+import { CaretDownIcon, CaretUpIcon } from "@phosphor-icons/react";
 
 import type {
     CompetitorScore,
@@ -87,9 +87,9 @@ export function CompetitorLeaderboard({
                                         <td className="px-4 py-4">
                                             <div className="flex items-center gap-2">
                                                 {isExpanded ? (
-                                                    <CaretUp className="text-foreground/40 h-4 w-4" />
+                                                    <CaretUpIcon className="text-foreground/40 h-4 w-4" />
                                                 ) : (
-                                                    <CaretDown className="text-foreground/40 h-4 w-4" />
+                                                    <CaretDownIcon className="text-foreground/40 h-4 w-4" />
                                                 )}
                                                 <span className="text-foreground font-medium">
                                                     {competitor.competitor}

--- a/components/benchmarks/query-detail-modal.tsx
+++ b/components/benchmarks/query-detail-modal.tsx
@@ -7,7 +7,12 @@
  * Uses shadcn Dialog (Radix) for proper modal behavior.
  */
 
-import { Clock, Trophy, WarningCircle, Handshake } from "@phosphor-icons/react";
+import {
+    ClockIcon,
+    TrophyIcon,
+    WarningCircleIcon,
+    HandshakeIcon,
+} from "@phosphor-icons/react";
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import type { QueryResult, PairwiseResult } from "@/lib/benchmarks/types";
@@ -96,7 +101,7 @@ export function QueryDetailModal({
                                         Carmenta
                                     </h3>
                                     <div className="text-muted-foreground flex items-center gap-1 text-sm">
-                                        <Clock className="h-3 w-3" />
+                                        <ClockIcon className="h-3 w-3" />
                                         {formatLatency(
                                             query.carmentaResponse.latencyMs
                                         )}
@@ -117,7 +122,7 @@ export function QueryDetailModal({
                                     </h3>
                                     {competitorResponse && (
                                         <div className="text-muted-foreground flex items-center gap-1 text-sm">
-                                            <Clock className="h-3 w-3" />
+                                            <ClockIcon className="h-3 w-3" />
                                             {formatLatency(
                                                 competitorResponse.latencyMs
                                             )}
@@ -145,11 +150,11 @@ function WinnerIcon({ winner }: { winner: "carmenta" | "competitor" | "tie" }) {
 
     switch (winner) {
         case "carmenta":
-            return <Trophy className={`${iconClass} text-green-500`} />;
+            return <TrophyIcon className={`${iconClass} text-green-500`} />;
         case "competitor":
-            return <WarningCircle className={`${iconClass} text-red-500`} />;
+            return <WarningCircleIcon className={`${iconClass} text-red-500`} />;
         case "tie":
-            return <Handshake className={`${iconClass} text-yellow-500`} />;
+            return <HandshakeIcon className={`${iconClass} text-yellow-500`} />;
     }
 }
 

--- a/components/brand/button-state-demo.tsx
+++ b/components/brand/button-state-demo.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useRef, useCallback } from "react";
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { triggerHaptic } from "@/lib/hooks/use-haptic-feedback";
 import { createRipple, getTapPosition } from "@/lib/hooks/use-tap-feedback";
@@ -100,7 +100,7 @@ export function ButtonStateDemo({ variant }: { variant: string }) {
                 )}
 
                 {/* Icon */}
-                <Sparkle
+                <SparkleIcon
                     className={cn(
                         "relative z-10 h-5 w-5 transition-colors",
                         variant === "hover"

--- a/components/carmenta-assistant/carmenta-layout.tsx
+++ b/components/carmenta-assistant/carmenta-layout.tsx
@@ -24,7 +24,7 @@ import {
     useEffect,
 } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Sparkle, CaretLeft, Trash } from "@phosphor-icons/react";
+import { SparkleIcon, CaretLeftIcon, TrashIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
@@ -207,7 +207,10 @@ function DesktopPanel({
             <header className="border-foreground/[0.08] flex shrink-0 items-center justify-between border-b px-4 py-3">
                 <div className="flex items-center gap-2.5">
                     <div className="bg-primary/20 flex h-8 w-8 items-center justify-center rounded-full">
-                        <Sparkle className="text-primary h-4 w-4" weight="duotone" />
+                        <SparkleIcon
+                            className="text-primary h-4 w-4"
+                            weight="duotone"
+                        />
                     </div>
                     <div>
                         <h2 className="text-foreground text-sm font-medium">
@@ -227,7 +230,7 @@ function DesktopPanel({
                             aria-label="Clear conversation"
                             title="Clear conversation"
                         >
-                            <Trash className="h-4 w-4" />
+                            <TrashIcon className="h-4 w-4" />
                         </button>
                     )}
                     <button
@@ -235,7 +238,7 @@ function DesktopPanel({
                         className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors"
                         aria-label="Collapse panel"
                     >
-                        <CaretLeft className="h-4 w-4" />
+                        <CaretLeftIcon className="h-4 w-4" />
                     </button>
                 </div>
             </header>

--- a/components/carmenta-assistant/carmenta-panel.tsx
+++ b/components/carmenta-assistant/carmenta-panel.tsx
@@ -11,7 +11,7 @@
 
 import { useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Sparkle, CaretLeft, Trash } from "@phosphor-icons/react";
+import { SparkleIcon, CaretLeftIcon, TrashIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
@@ -126,7 +126,7 @@ export function CarmentaPanel({
                         <header className="border-foreground/[0.08] flex items-center justify-between border-b px-4 py-3">
                             <div className="flex items-center gap-2.5">
                                 <div className="bg-primary/20 flex h-8 w-8 items-center justify-center rounded-full">
-                                    <Sparkle
+                                    <SparkleIcon
                                         className="text-primary h-4 w-4"
                                         weight="duotone"
                                     />
@@ -150,7 +150,7 @@ export function CarmentaPanel({
                                         aria-label="Clear conversation"
                                         title="Clear conversation"
                                     >
-                                        <Trash className="h-4 w-4" />
+                                        <TrashIcon className="h-4 w-4" />
                                     </button>
                                 )}
 
@@ -160,7 +160,7 @@ export function CarmentaPanel({
                                     className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors"
                                     aria-label="Collapse panel"
                                 >
-                                    <CaretLeft className="h-4 w-4" />
+                                    <CaretLeftIcon className="h-4 w-4" />
                                 </button>
                             </div>
                         </header>

--- a/components/carmenta-assistant/empty-state.tsx
+++ b/components/carmenta-assistant/empty-state.tsx
@@ -8,7 +8,7 @@
  */
 
 import { motion } from "framer-motion";
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 
 interface EmptyStateProps {
     pageContext?: string;
@@ -46,7 +46,7 @@ export function EmptyState({ pageContext }: EmptyStateProps) {
             className="flex h-full flex-col items-center justify-center p-6 text-center"
         >
             <div className="bg-primary/10 mb-4 flex h-14 w-14 items-center justify-center rounded-full">
-                <Sparkle className="text-primary/50 h-7 w-7" weight="duotone" />
+                <SparkleIcon className="text-primary/50 h-7 w-7" weight="duotone" />
             </div>
             <p className="text-foreground/50 max-w-[280px] text-sm leading-relaxed">
                 {hint}

--- a/components/carmenta-assistant/index.tsx
+++ b/components/carmenta-assistant/index.tsx
@@ -40,7 +40,7 @@
  * ```
  */
 
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 // Export components
@@ -93,7 +93,7 @@ export function CarmentaToggle({
             aria-label={isOpen ? "Close Carmenta" : "Open Carmenta"}
             aria-expanded={isOpen}
         >
-            <Sparkle
+            <SparkleIcon
                 className={cn("h-5 w-5", isOpen && "text-primary")}
                 weight={isOpen ? "fill" : "duotone"}
             />

--- a/components/carmenta-concierge/message.tsx
+++ b/components/carmenta-concierge/message.tsx
@@ -9,7 +9,12 @@
 
 import { motion } from "framer-motion";
 import type { UIMessage } from "@ai-sdk/react";
-import { CircleNotch, Wrench, CheckCircle, XCircle } from "@phosphor-icons/react";
+import {
+    CircleNotchIcon,
+    WrenchIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { getToolDisplayName } from "@/lib/ai-team/dcos/tool-display";
@@ -51,7 +56,7 @@ export function ConciergeMessage({ message, isLoading }: ConciergeMessageProps) 
                 {/* Loading indicator for streaming */}
                 {!isUser && isLoading && message.parts.length === 0 && (
                     <div className="text-foreground/60 flex items-center gap-2">
-                        <CircleNotch className="h-3.5 w-3.5 animate-spin" />
+                        <CircleNotchIcon className="h-3.5 w-3.5 animate-spin" />
                         <span className="text-xs">Thinking...</span>
                     </div>
                 )}
@@ -125,11 +130,11 @@ function ToolPart({ part }: { part: Record<string, unknown> }) {
             )}
         >
             {isError ? (
-                <XCircle className="h-3 w-3 flex-shrink-0" weight="fill" />
+                <XCircleIcon className="h-3 w-3 flex-shrink-0" weight="fill" />
             ) : isComplete ? (
-                <CheckCircle className="h-3 w-3 flex-shrink-0" weight="fill" />
+                <CheckCircleIcon className="h-3 w-3 flex-shrink-0" weight="fill" />
             ) : (
-                <Wrench className="h-3 w-3 flex-shrink-0 animate-pulse" />
+                <WrenchIcon className="h-3 w-3 flex-shrink-0 animate-pulse" />
             )}
             <span className="truncate">{displayName}</span>
         </div>

--- a/components/carmenta-modal/index.tsx
+++ b/components/carmenta-modal/index.tsx
@@ -12,7 +12,7 @@
 
 import { useRef, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
@@ -63,7 +63,7 @@ export function CarmentaModal() {
             >
                 {/* Header */}
                 <div className="border-foreground/10 flex items-center gap-2 border-b px-4 py-3">
-                    <Sparkle
+                    <SparkleIcon
                         weight="duotone"
                         className="text-primary h-5 w-5 animate-pulse"
                     />
@@ -134,7 +134,7 @@ function EmptyState() {
             animate={{ opacity: 1, y: 0 }}
             className="flex h-full flex-col items-center justify-center py-8 text-center"
         >
-            <Sparkle weight="duotone" className="text-primary/30 mb-3 h-12 w-12" />
+            <SparkleIcon weight="duotone" className="text-primary/30 mb-3 h-12 w-12" />
             <p className="text-foreground/60 max-w-xs text-sm">
                 We're here to help. Ask about your knowledge base, connected services,
                 or anything else.

--- a/components/carmenta-modal/message.tsx
+++ b/components/carmenta-modal/message.tsx
@@ -9,7 +9,12 @@
 
 import { motion } from "framer-motion";
 import type { UIMessage } from "@ai-sdk/react";
-import { CircleNotch, Wrench, CheckCircle, XCircle } from "@phosphor-icons/react";
+import {
+    CircleNotchIcon,
+    WrenchIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { getToolDisplayName } from "@/lib/ai-team/dcos/tool-display";
@@ -52,7 +57,7 @@ export function CarmentaMessage({ message, isLoading }: CarmentaMessageProps) {
                 {/* Show loading indicator for assistant messages that are streaming */}
                 {!isUser && isLoading && message.parts.length === 0 && (
                     <div className="text-foreground/60 flex items-center gap-2">
-                        <CircleNotch className="h-4 w-4 animate-spin" />
+                        <CircleNotchIcon className="h-4 w-4 animate-spin" />
                         <span className="text-sm">Thinking...</span>
                     </div>
                 )}
@@ -133,11 +138,11 @@ function ToolPart({ part }: { part: Record<string, unknown> }) {
             )}
         >
             {isError ? (
-                <XCircle className="h-3.5 w-3.5 flex-shrink-0" weight="fill" />
+                <XCircleIcon className="h-3.5 w-3.5 flex-shrink-0" weight="fill" />
             ) : isComplete ? (
-                <CheckCircle className="h-3.5 w-3.5 flex-shrink-0" weight="fill" />
+                <CheckCircleIcon className="h-3.5 w-3.5 flex-shrink-0" weight="fill" />
             ) : (
-                <Wrench className="h-3.5 w-3.5 flex-shrink-0 animate-pulse" />
+                <WrenchIcon className="h-3.5 w-3.5 flex-shrink-0 animate-pulse" />
             )}
             <span className="truncate">{displayName}</span>
         </div>

--- a/components/chat/message-bubbles.tsx
+++ b/components/chat/message-bubbles.tsx
@@ -9,7 +9,7 @@
 
 import { memo } from "react";
 import { motion } from "framer-motion";
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
@@ -110,7 +110,7 @@ export const ThinkingBubble = memo(function ThinkingBubble({
                 )}
                 <div className="assistant-message-bubble rounded-2xl rounded-bl-md border-l-[3px] border-l-cyan-400 px-4 py-3">
                     <div className="text-foreground/60 flex items-center gap-2 text-sm">
-                        <Sparkle className="h-4 w-4 animate-pulse" />
+                        <SparkleIcon className="h-4 w-4 animate-pulse" />
                         <span>{message}</span>
                     </div>
                 </div>

--- a/components/chat/simple-composer.tsx
+++ b/components/chat/simple-composer.tsx
@@ -14,7 +14,7 @@
  */
 
 import { useRef, useEffect, useCallback } from "react";
-import { ArrowElbowDownLeft, Square } from "@phosphor-icons/react";
+import { ArrowElbowDownLeftIcon, SquareIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 
@@ -131,9 +131,9 @@ export function SimpleComposer({
                 aria-label={isLoading ? "Stop" : "Send message"}
             >
                 {isLoading ? (
-                    <Square className="h-4 w-4 sm:h-5 sm:w-5" />
+                    <SquareIcon className="h-4 w-4 sm:h-5 sm:w-5" />
                 ) : (
-                    <ArrowElbowDownLeft className="h-5 w-5 sm:h-6 sm:w-6" />
+                    <ArrowElbowDownLeftIcon className="h-5 w-5 sm:h-6 sm:w-6" />
                 )}
             </button>
         </div>

--- a/components/code-mode/file-tree.tsx
+++ b/components/code-mode/file-tree.tsx
@@ -17,7 +17,7 @@ import {
     type KeyboardEvent,
 } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import {
@@ -26,13 +26,13 @@ import {
     formatFileSize,
 } from "@/lib/code-mode/file-utils";
 import {
-    File,
-    FileCode,
-    FileJs,
-    FileText,
-    Image as FileImage,
-    Folder,
-    FolderOpen,
+    FileIcon as FileIconPhosphor,
+    FileCodeIcon,
+    FileJsIcon,
+    FileTextIcon,
+    ImageIcon as FileImage,
+    FolderIcon,
+    FolderOpenIcon,
 } from "@phosphor-icons/react";
 
 interface FileTreeProps {
@@ -145,20 +145,20 @@ function FileIcon({
 }) {
     if (file.type === "directory") {
         return isOpen ? (
-            <FolderOpen className={className} />
+            <FolderOpenIcon className={className} />
         ) : (
-            <Folder className={className} />
+            <FolderIcon className={className} />
         );
     }
 
     const ext = file.extension?.toLowerCase() ?? "";
 
-    if (CODE_EXTENSIONS.has(ext)) return <FileCode className={className} />;
-    if (CONFIG_EXTENSIONS.has(ext)) return <FileJs className={className} />;
-    if (TEXT_EXTENSIONS.has(ext)) return <FileText className={className} />;
+    if (CODE_EXTENSIONS.has(ext)) return <FileCodeIcon className={className} />;
+    if (CONFIG_EXTENSIONS.has(ext)) return <FileJsIcon className={className} />;
+    if (TEXT_EXTENSIONS.has(ext)) return <FileTextIcon className={className} />;
     if (IMAGE_EXTENSIONS.has(ext)) return <FileImage className={className} />;
 
-    return <File className={className} />;
+    return <FileIconPhosphor className={className} />;
 }
 
 /**
@@ -276,7 +276,7 @@ const FileTreeItem = memo(function FileTreeItem({
                         transition={{ duration: 0.15 }}
                         className="flex-shrink-0"
                     >
-                        <CaretRight className="text-muted-foreground h-3.5 w-3.5" />
+                        <CaretRightIcon className="text-muted-foreground h-3.5 w-3.5" />
                     </motion.div>
                 )}
 

--- a/components/connection/collapsible-streaming-content.tsx
+++ b/components/connection/collapsible-streaming-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useMemo } from "react";
-import { CaretDown } from "@phosphor-icons/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { cn } from "@/lib/utils";
@@ -127,7 +127,7 @@ export function CollapsibleStreamingContent({
                 </div>
 
                 {/* Expand/collapse chevron */}
-                <CaretDown
+                <CaretDownIcon
                     className={cn(
                         "text-foreground/40 h-4 w-4 shrink-0 transition-transform duration-200",
                         !isCollapsed && "rotate-180",

--- a/components/connection/composer.tsx
+++ b/components/connection/composer.tsx
@@ -22,7 +22,7 @@ import {
     type ComponentProps,
 } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Square, ArrowElbowDownLeft, Plus } from "@phosphor-icons/react";
+import { SquareIcon, ArrowElbowDownLeftIcon, PlusIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { useMessageQueue, type QueuedMessage } from "@/lib/hooks/use-message-queue";
@@ -777,7 +777,7 @@ export function Composer({ onMarkMessageStopped }: ComposerProps) {
                                 data-testid="send-button"
                                 className={isMobile === true ? "h-11 w-11" : ""}
                             >
-                                <ArrowElbowDownLeft className="h-5 w-5 sm:h-6 sm:w-6" />
+                                <ArrowElbowDownLeftIcon className="h-5 w-5 sm:h-6 sm:w-6" />
                             </ComposerButton>
                         ) : input.trim() ? (
                             <ComposerButton
@@ -803,7 +803,10 @@ export function Composer({ onMarkMessageStopped }: ComposerProps) {
                                 data-testid="queue-button"
                                 className={isMobile === true ? "h-11 w-11" : ""}
                             >
-                                <Plus className="h-5 w-5 sm:h-6 sm:w-6" weight="bold" />
+                                <PlusIcon
+                                    className="h-5 w-5 sm:h-6 sm:w-6"
+                                    weight="bold"
+                                />
                             </ComposerButton>
                         ) : (
                             <ComposerButton
@@ -815,7 +818,7 @@ export function Composer({ onMarkMessageStopped }: ComposerProps) {
                                 data-testid="stop-button"
                                 className={isMobile === true ? "h-11 w-11" : ""}
                             >
-                                <Square className="h-4 w-4 sm:h-5 sm:w-5" />
+                                <SquareIcon className="h-4 w-4 sm:h-5 sm:w-5" />
                             </ComposerButton>
                         )}
                         <VoiceInputButton
@@ -964,7 +967,7 @@ const ComposerButton = forwardRef<HTMLButtonElement, ComposerButtonProps>(
         // Queue and Send variants use children (passed as props)
         const getIcon = () => {
             if (variant === "stop") {
-                return <Square className="h-4 w-4 sm:h-5 sm:w-5" />;
+                return <SquareIcon className="h-4 w-4 sm:h-5 sm:w-5" />;
             }
             // Send, queue, and ghost variants use children
             return children;

--- a/components/connection/concierge-display.tsx
+++ b/components/connection/concierge-display.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { memo, useState } from "react";
-import { CaretDown, CircleNotch, ArrowsLeftRight } from "@phosphor-icons/react";
+import {
+    CaretDownIcon,
+    CircleNotchIcon,
+    ArrowsLeftRightIcon,
+} from "@phosphor-icons/react";
 import { motion } from "framer-motion";
 
 import { cn } from "@/lib/utils";
@@ -216,7 +220,7 @@ export const ConciergeDisplay = memo(function ConciergeDisplay({
                                 <span className="text-foreground/90 text-sm">
                                     {selectingMessage}
                                 </span>
-                                <CircleNotch className="text-foreground/50 h-3.5 w-3.5 animate-spin" />
+                                <CircleNotchIcon className="text-foreground/50 h-3.5 w-3.5 animate-spin" />
                             </motion.div>
                         )}
 
@@ -323,12 +327,12 @@ export const ConciergeDisplay = memo(function ConciergeDisplay({
                                         }}
                                         className="flex items-center gap-1 rounded-full bg-amber-500/10 px-1.5 py-0.5"
                                     >
-                                        <ArrowsLeftRight className="h-3 w-3 text-amber-600 dark:text-amber-400" />
+                                        <ArrowsLeftRightIcon className="h-3 w-3 text-amber-600 dark:text-amber-400" />
                                     </motion.div>
                                 )}
 
                                 {/* Expand chevron - appears on hover */}
-                                <CaretDown
+                                <CaretDownIcon
                                     className={cn(
                                         "text-foreground/25 ml-auto h-4 w-4 shrink-0 transition-all duration-200",
                                         "opacity-0 group-hover:opacity-100",
@@ -382,7 +386,7 @@ export const ConciergeDisplay = memo(function ConciergeDisplay({
                             {/* Auto-switch notice */}
                             {autoSwitched && autoSwitchReason && (
                                 <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-500/20 bg-amber-500/5 px-3 py-2">
-                                    <ArrowsLeftRight className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                                    <ArrowsLeftRightIcon className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
                                     <p className="text-amber-700 dark:text-amber-300">
                                         {autoSwitchReason}
                                     </p>

--- a/components/connection/connect-layout.tsx
+++ b/components/connection/connect-layout.tsx
@@ -27,7 +27,11 @@
 
 import { type ReactNode } from "react";
 import { motion } from "framer-motion";
-import { Plus, CircleNotch, FolderSimpleDashed } from "@phosphor-icons/react";
+import {
+    PlusIcon,
+    CircleNotchIcon,
+    FolderSimpleDashedIcon,
+} from "@phosphor-icons/react";
 
 import { ConnectionProvider, useConnection } from "./connection-context";
 import { ConnectRuntimeProvider, useCodeMode } from "./connect-runtime-provider";
@@ -91,7 +95,7 @@ function CodeModeIndicator() {
             animate={{ opacity: 1, scale: 1 }}
             title={`Code mode: ${projectPath}`}
         >
-            <FolderSimpleDashed className="h-4 w-4" />
+            <FolderSimpleDashedIcon className="h-4 w-4" />
             <span className="max-w-[120px] truncate">{projectName}</span>
         </motion.div>
     );
@@ -199,9 +203,9 @@ function ConnectLayoutInner({ children }: { children: ReactNode }) {
                                         aria-label="New connection"
                                     >
                                         {isPending ? (
-                                            <CircleNotch className="h-4 w-4 animate-spin" />
+                                            <CircleNotchIcon className="h-4 w-4 animate-spin" />
                                         ) : (
-                                            <Plus className="h-4 w-4" />
+                                            <PlusIcon className="h-4 w-4" />
                                         )}
                                         <span className="text-sm font-medium">
                                             New Connection

--- a/components/connection/connect-runtime-provider.tsx
+++ b/components/connection/connect-runtime-provider.tsx
@@ -24,7 +24,7 @@ import {
 } from "react";
 import { useChat, type UIMessage } from "@ai-sdk/react";
 import { DefaultChatTransport, generateId } from "ai";
-import { WarningCircle, ArrowsClockwise, X } from "@phosphor-icons/react";
+import { WarningCircleIcon, ArrowsClockwiseIcon, XIcon } from "@phosphor-icons/react";
 import { toast } from "sonner";
 
 import { logger } from "@/lib/client-logger";
@@ -398,7 +398,7 @@ function RuntimeErrorBanner({
             )}
             role="alert"
         >
-            <WarningCircle className="h-5 w-5 shrink-0 text-red-500" />
+            <WarningCircleIcon className="h-5 w-5 shrink-0 text-red-500" />
             <div className="flex-1">
                 <p className="text-sm font-medium text-red-800">{displayMessage}</p>
             </div>
@@ -408,14 +408,14 @@ function RuntimeErrorBanner({
                     className="rounded-lg p-2 text-red-600 transition-colors hover:bg-red-100"
                     aria-label="Retry"
                 >
-                    <ArrowsClockwise className="h-4 w-4" />
+                    <ArrowsClockwiseIcon className="h-4 w-4" />
                 </button>
                 <button
                     onClick={onDismiss}
                     className="rounded-lg p-2 text-red-600 transition-colors hover:bg-red-100"
                     aria-label="Dismiss"
                 >
-                    <X className="h-4 w-4" />
+                    <XIcon className="h-4 w-4" />
                 </button>
             </div>
         </div>

--- a/components/connection/draft-recovery-banner.tsx
+++ b/components/connection/draft-recovery-banner.tsx
@@ -15,7 +15,7 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import { ClockCounterClockwise } from "@phosphor-icons/react";
+import { ClockCounterClockwiseIcon } from "@phosphor-icons/react";
 
 interface DraftRecoveryBannerProps {
     /** Whether to show the banner */
@@ -47,7 +47,7 @@ export function DraftRecoveryBanner({
                 >
                     <div className="bg-primary/10 mb-3 flex items-center justify-between rounded-xl px-4 py-3">
                         <div className="flex items-center gap-2">
-                            <ClockCounterClockwise className="text-primary h-4 w-4" />
+                            <ClockCounterClockwiseIcon className="text-primary h-4 w-4" />
                             <span className="text-foreground/80 text-sm">
                                 We kept your message safe.
                             </span>

--- a/components/connection/drag-drop-overlay.tsx
+++ b/components/connection/drag-drop-overlay.tsx
@@ -11,7 +11,12 @@
  */
 
 import { memo } from "react";
-import { Upload, Image, FileText, MusicNote } from "@phosphor-icons/react";
+import {
+    UploadIcon,
+    ImageIcon,
+    FileTextIcon,
+    MusicNoteIcon,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 interface DragDropOverlayProps {
@@ -115,7 +120,7 @@ export const DragDropOverlay = memo(function DragDropOverlay({
                                 isActive && "scale-110"
                             )}
                         >
-                            <Upload
+                            <UploadIcon
                                 className={cn(
                                     "text-primary h-10 w-10 transition-transform duration-300",
                                     isActive && "-translate-y-1"
@@ -136,9 +141,9 @@ export const DragDropOverlay = memo(function DragDropOverlay({
 
                     {/* Supported file types row */}
                     <div className="mt-6 flex items-center gap-4">
-                        <FileTypeIndicator icon={Image} label="Images" />
-                        <FileTypeIndicator icon={FileText} label="PDFs" />
-                        <FileTypeIndicator icon={MusicNote} label="Audio" />
+                        <FileTypeIndicator icon={ImageIcon} label="Images" />
+                        <FileTypeIndicator icon={FileTextIcon} label="PDFs" />
+                        <FileTypeIndicator icon={MusicNoteIcon} label="Audio" />
                     </div>
                 </div>
             </div>
@@ -151,7 +156,7 @@ function FileTypeIndicator({
     icon: Icon,
     label,
 }: {
-    icon: typeof Image;
+    icon: typeof ImageIcon;
     label: string;
 }) {
     return (

--- a/components/connection/file-picker-button.tsx
+++ b/components/connection/file-picker-button.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useRef } from "react";
-import { Paperclip } from "@phosphor-icons/react";
+import { PaperclipIcon } from "@phosphor-icons/react";
 import { useFileAttachments } from "./file-attachment-context";
 import { ALLOWED_MIME_TYPES } from "@/lib/storage/file-config";
 import { cn } from "@/lib/utils";
@@ -47,7 +47,7 @@ export function FilePickerButton({ className }: FilePickerButtonProps) {
                 data-tooltip-content="Add files · up to 10MB"
                 aria-label="Attach file"
             >
-                <Paperclip className="text-foreground/50 group-hover:text-foreground/80 h-5 w-5 transition-colors sm:h-6 sm:w-6" />
+                <PaperclipIcon className="text-foreground/50 group-hover:text-foreground/80 h-5 w-5 transition-colors sm:h-6 sm:w-6" />
             </button>
             <input
                 ref={inputRef}

--- a/components/connection/file-preview.tsx
+++ b/components/connection/file-preview.tsx
@@ -11,7 +11,12 @@
 
 import { useState } from "react";
 import Image from "next/image";
-import { File, FileText, MusicNote, ImageBroken } from "@phosphor-icons/react";
+import {
+    FileIcon,
+    FileTextIcon,
+    MusicNoteIcon,
+    ImageBrokenIcon,
+} from "@phosphor-icons/react";
 import { ALLOWED_MIME_TYPES } from "@/lib/storage/file-config";
 import { getThumbnailUrl } from "@/lib/storage/upload";
 import { cn } from "@/lib/utils";
@@ -41,7 +46,7 @@ export function FilePreview({
         if (hasError) {
             return (
                 <div className="border-foreground/10 bg-background/80 text-foreground/50 flex items-center gap-2 rounded-lg border px-3 py-2">
-                    <ImageBroken className="h-5 w-5 shrink-0" />
+                    <ImageBrokenIcon className="h-5 w-5 shrink-0" />
                     <span className="text-sm">Image unavailable</span>
                 </div>
             );
@@ -77,9 +82,9 @@ export function FilePreview({
     }
 
     // Non-image files: Show icon + filename
-    let Icon = File;
-    if (isPDF) Icon = FileText;
-    else if (isAudio) Icon = MusicNote;
+    let Icon = FileIcon;
+    if (isPDF) Icon = FileTextIcon;
+    else if (isAudio) Icon = MusicNoteIcon;
     // else Icon = File (already set as default)
 
     return (

--- a/components/connection/holo-thread.tsx
+++ b/components/connection/holo-thread.tsx
@@ -20,7 +20,7 @@ import {
 } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
-import { CaretDown, X, Pencil, Check } from "@phosphor-icons/react";
+import { CaretDownIcon, XIcon, PencilIcon, CheckIcon } from "@phosphor-icons/react";
 import { useChatScroll } from "@/lib/hooks/use-chat-scroll";
 import { usePullToRefresh } from "@/lib/hooks/use-pull-to-refresh";
 import { PullToRefreshIndicator } from "@/components/pwa/pull-to-refresh-indicator";
@@ -336,7 +336,7 @@ const ScrollToBottomButton = memo(function ScrollToBottomButton({
             className="btn-glass-interactive z-sticky absolute -top-14 flex h-11 w-11 items-center justify-center sm:-top-12 sm:h-10 sm:w-10"
             aria-label="Scroll to bottom"
         >
-            <CaretDown className="text-foreground/70 h-5 w-5" />
+            <CaretDownIcon className="text-foreground/70 h-5 w-5" />
         </button>
     );
 });
@@ -1376,7 +1376,7 @@ function MessageActions({
                         "text-foreground/60 hover:text-foreground/90"
                     )}
                 >
-                    <Pencil className="h-4 w-4" />
+                    <PencilIcon className="h-4 w-4" />
                 </button>
             )}
             <CopyButton
@@ -1606,7 +1606,7 @@ function UserMessage({ message, isLast }: { message: UIMessage; isLast: boolean 
                                         isSubmitting && "cursor-not-allowed opacity-50"
                                     )}
                                 >
-                                    <X className="h-3 w-3" />
+                                    <XIcon className="h-3 w-3" />
                                     Cancel
                                 </button>
                                 <button
@@ -1624,7 +1624,7 @@ function UserMessage({ message, isLast }: { message: UIMessage; isLast: boolean 
                                             "cursor-not-allowed opacity-50"
                                     )}
                                 >
-                                    <Check className="h-3 w-3" />
+                                    <CheckIcon className="h-3 w-3" />
                                     {isSubmitting ? "Saving..." : "Save & Regenerate"}
                                 </button>
                             </div>

--- a/components/connection/message-queue-display.tsx
+++ b/components/connection/message-queue-display.tsx
@@ -15,7 +15,7 @@
 
 import { useState, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, PencilSimple, Lightning } from "@phosphor-icons/react";
+import { XIcon, PencilSimpleIcon, LightningIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import type { QueuedMessage } from "@/lib/hooks/use-message-queue";
@@ -169,7 +169,7 @@ export function MessageQueueDisplay({
                                             )}
                                             title="Send now (interrupts current)"
                                         >
-                                            <Lightning
+                                            <LightningIcon
                                                 className="h-3.5 w-3.5"
                                                 weight="fill"
                                             />
@@ -186,7 +186,7 @@ export function MessageQueueDisplay({
                                         )}
                                         title="Edit message"
                                     >
-                                        <PencilSimple className="h-3.5 w-3.5" />
+                                        <PencilSimpleIcon className="h-3.5 w-3.5" />
                                     </button>
 
                                     {/* Remove button */}
@@ -199,7 +199,7 @@ export function MessageQueueDisplay({
                                         )}
                                         title="Remove from queue"
                                     >
-                                        <X className="h-3.5 w-3.5" />
+                                        <XIcon className="h-3.5 w-3.5" />
                                     </button>
                                 </div>
                             )}

--- a/components/connection/model-selector/model-selector-modal.tsx
+++ b/components/connection/model-selector/model-selector-modal.tsx
@@ -10,7 +10,12 @@
  */
 
 import { useRef, useState, useEffect } from "react";
-import { Sparkle, Check, Info, CircleNotch } from "@phosphor-icons/react";
+import {
+    SparkleIcon,
+    CheckIcon,
+    InfoIcon,
+    CircleNotchIcon,
+} from "@phosphor-icons/react";
 
 import {
     Dialog,
@@ -211,9 +216,9 @@ export function ModelSelectorModal({
                         </span>
                         <div className="from-primary flex h-14 w-14 shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br to-purple-500 shadow-lg">
                             {switchingTo === "auto" ? (
-                                <CircleNotch className="h-7 w-7 animate-spin text-white" />
+                                <CircleNotchIcon className="h-7 w-7 animate-spin text-white" />
                             ) : (
-                                <Sparkle className="h-7 w-7 text-white" />
+                                <SparkleIcon className="h-7 w-7 text-white" />
                             )}
                         </div>
                         <div className="min-w-0 flex-1">
@@ -238,7 +243,7 @@ export function ModelSelectorModal({
                         </div>
                         {overrides.modelId === null && (
                             <div className="bg-primary flex h-8 w-8 shrink-0 items-center justify-center rounded-full shadow-md">
-                                <Check className="h-5 w-5 text-white" />
+                                <CheckIcon className="h-5 w-5 text-white" />
                             </div>
                         )}
                     </button>
@@ -273,11 +278,11 @@ export function ModelSelectorModal({
                                         data-tooltip-html={getModelTooltipHtml(model)}
                                         onClick={(e) => e.stopPropagation()}
                                     >
-                                        <Info className="text-foreground/40 hover:text-foreground/70 h-3.5 w-3.5 transition-colors" />
+                                        <InfoIcon className="text-foreground/40 hover:text-foreground/70 h-3.5 w-3.5 transition-colors" />
                                     </div>
                                     <div className="relative mt-0.5 h-6 w-6 shrink-0">
                                         {isSwitching ? (
-                                            <CircleNotch className="text-primary h-6 w-6 animate-spin" />
+                                            <CircleNotchIcon className="text-primary h-6 w-6 animate-spin" />
                                         ) : (
                                             <ProviderIcon
                                                 provider={model.provider}
@@ -324,7 +329,7 @@ export function ModelSelectorModal({
                                     </div>
                                     {isSelected && (
                                         <div className="bg-primary flex h-6 w-6 shrink-0 items-center justify-center rounded-full shadow-sm">
-                                            <Check className="h-4 w-4 text-white" />
+                                            <CheckIcon className="h-4 w-4 text-white" />
                                         </div>
                                     )}
                                 </button>
@@ -386,7 +391,7 @@ export function ModelSelectorModal({
                             }}
                             className="text-muted-foreground hover:text-primary hover:bg-primary/10 flex items-center gap-1.5 rounded-full px-4 py-1.5 text-xs font-medium transition-all"
                         >
-                            <Sparkle className="h-3 w-3" />
+                            <SparkleIcon className="h-3 w-3" />
                             Let Carmenta decide automagically
                         </button>
                     </div>

--- a/components/connection/model-selector/model-selector-trigger.tsx
+++ b/components/connection/model-selector/model-selector-trigger.tsx
@@ -10,7 +10,7 @@
  * other components (like feature tips) can also trigger the modal.
  */
 
-import { Sparkle } from "@phosphor-icons/react";
+import { SparkleIcon } from "@phosphor-icons/react";
 
 import { MODELS, type ModelConfig } from "@/lib/model-config";
 import { ProviderIcon } from "@/components/icons/provider-icons";
@@ -85,7 +85,7 @@ export function ModelSelectorTrigger({
                 {/* showLabel mode: sparkles (+ optional label), otherwise provider icon */}
                 {showLabel ? (
                     <>
-                        <Sparkle
+                        <SparkleIcon
                             className={cn(
                                 "h-5 w-5 transition-colors",
                                 labelText
@@ -112,7 +112,7 @@ export function ModelSelectorTrigger({
                         )}
                     />
                 ) : (
-                    <Sparkle className="text-primary/70 group-hover:text-primary h-5 w-5 transition-colors sm:h-6 sm:w-6" />
+                    <SparkleIcon className="text-primary/70 group-hover:text-primary h-5 w-5 transition-colors sm:h-6 sm:w-6" />
                 )}
             </button>
 

--- a/components/connection/reasoning-display.tsx
+++ b/components/connection/reasoning-display.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { memo, useEffect, useState, useId, useRef, useMemo } from "react";
-import { Brain, CaretDown } from "@phosphor-icons/react";
+import { BrainIcon, CaretDownIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import {
@@ -246,7 +246,7 @@ export const ReasoningDisplay = memo(function ReasoningDisplay({
                 )}
                 data-testid="reasoning-trigger"
             >
-                <Brain
+                <BrainIcon
                     className={cn(
                         "h-3.5 w-3.5 text-blue-500/70",
                         isStreaming && "animate-pulse"
@@ -262,7 +262,7 @@ export const ReasoningDisplay = memo(function ReasoningDisplay({
                 >
                     {statusMessage}
                 </span>
-                <CaretDown
+                <CaretDownIcon
                     className={cn(
                         "h-4 w-4 shrink-0 transition-transform duration-200",
                         isNested && "text-foreground/40",

--- a/components/connection/sparks.tsx
+++ b/components/connection/sparks.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { motion } from "framer-motion";
-import { ArrowRight } from "@phosphor-icons/react";
+import { ArrowRightIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { logger } from "@/lib/client-logger";
@@ -134,7 +134,7 @@ function SparkPill({ spark, onClick, index }: SparkPillProps) {
             />
             <span className="max-w-[200px] truncate">{spark.label}</span>
             {(isNavigate || isDeeplink) && (
-                <ArrowRight className="text-foreground/30 group-hover:text-foreground/50 h-3.5 w-3.5 transition-all group-hover:translate-x-0.5" />
+                <ArrowRightIcon className="text-foreground/30 group-hover:text-foreground/50 h-3.5 w-3.5 transition-all group-hover:translate-x-0.5" />
             )}
         </motion.button>
     );

--- a/components/connection/star-button.tsx
+++ b/components/connection/star-button.tsx
@@ -9,7 +9,7 @@
  * Uses consistent icon sizing with other connection actions.
  */
 
-import { Star } from "@phosphor-icons/react";
+import { StarIcon } from "@phosphor-icons/react";
 import { useEffect, useRef, useState } from "react";
 import { cn } from "@/lib/utils";
 import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
@@ -112,7 +112,7 @@ export function StarButton({
                     ))}
                 </span>
             )}
-            <Star
+            <StarIcon
                 weight={isStarred ? "fill" : "regular"}
                 className={cn(
                     iconSize,

--- a/components/docs-viewer/docs-content.tsx
+++ b/components/docs-viewer/docs-content.tsx
@@ -6,7 +6,7 @@
  * Read-only display for documentation with markdown rendering.
  */
 
-import { FileText, BookOpen } from "@phosphor-icons/react";
+import { FileTextIcon, BookOpenIcon } from "@phosphor-icons/react";
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer";
 import type { KBDocument } from "@/lib/kb/actions";
 
@@ -19,7 +19,7 @@ export function DocsContent({ document: doc }: DocsContentProps) {
         return (
             <main className="glass-card flex h-full max-h-[calc(100vh-16rem)] flex-1 items-center justify-center rounded-xl">
                 <div className="flex flex-col items-center gap-3 text-center">
-                    <BookOpen className="text-foreground/30 h-12 w-12" />
+                    <BookOpenIcon className="text-foreground/30 h-12 w-12" />
                     <p className="text-foreground/40">Select a document to read</p>
                 </div>
             </main>
@@ -34,7 +34,10 @@ export function DocsContent({ document: doc }: DocsContentProps) {
                 aria-label={doc.name}
                 className="border-foreground/5 flex items-center gap-3 border-b px-6 py-4"
             >
-                <FileText className="text-foreground/50 h-5 w-5" aria-hidden="true" />
+                <FileTextIcon
+                    className="text-foreground/50 h-5 w-5"
+                    aria-hidden="true"
+                />
                 <div className="flex flex-col">
                     <h2 className="text-foreground text-lg font-medium">{doc.name}</h2>
                     {doc.description && (

--- a/components/generative-ui/acknowledge.tsx
+++ b/components/generative-ui/acknowledge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Heart, Sparkle, Confetti } from "@phosphor-icons/react";
+import { HeartIcon, SparkleIcon, ConfettiIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -16,19 +16,19 @@ interface AcknowledgeResultProps {
 
 const typeConfig = {
     gratitude: {
-        icon: Heart,
+        icon: HeartIcon,
         bg: "bg-holo-mint/20",
         border: "border-l-emerald-400/50",
         iconColor: "text-emerald-500",
     },
     encouragement: {
-        icon: Sparkle,
+        icon: SparkleIcon,
         bg: "bg-holo-lavender/20",
         border: "border-l-violet-400/50",
         iconColor: "text-violet-500",
     },
     celebration: {
-        icon: Confetti,
+        icon: ConfettiIcon,
         bg: "bg-holo-gold/20",
         border: "border-l-amber-400/50",
         iconColor: "text-amber-500",

--- a/components/generative-ui/fetch-page.tsx
+++ b/components/generative-ui/fetch-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FileText, ArrowSquareOut } from "@phosphor-icons/react";
+import { FileTextIcon, ArrowSquareOutIcon } from "@phosphor-icons/react";
 
 import type { ToolStatus } from "@/lib/tools/tool-config";
 import { ToolRenderer } from "./tool-renderer";
@@ -65,7 +65,7 @@ function FetchPageContent({
         <div className="max-w-2xl">
             <div className="flex items-start justify-between gap-2">
                 <div className="flex items-center gap-2">
-                    <FileText className="text-primary h-4 w-4" />
+                    <FileTextIcon className="text-primary h-4 w-4" />
                     <span className="text-foreground font-medium">
                         {title || "Page Content"}
                     </span>
@@ -77,7 +77,7 @@ function FetchPageContent({
                     className="text-muted-foreground hover:text-primary flex items-center gap-1 text-xs"
                 >
                     <span className="hidden sm:inline">Open</span>
-                    <ArrowSquareOut className="h-3 w-3" />
+                    <ArrowSquareOutIcon className="h-3 w-3" />
                 </a>
             </div>
 

--- a/components/generative-ui/gif-card.tsx
+++ b/components/generative-ui/gif-card.tsx
@@ -9,7 +9,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import Image from "next/image";
-import { ArrowSquareOut, Copy, Check } from "@phosphor-icons/react";
+import { ArrowSquareOutIcon, CopyIcon, CheckIcon } from "@phosphor-icons/react";
 import * as Sentry from "@sentry/nextjs";
 
 import { cn } from "@/lib/utils";
@@ -180,9 +180,9 @@ export function GifCard({ gif, compact = false, className }: GifCardProps) {
                         data-tooltip-content="Copy link"
                     >
                         {copied ? (
-                            <Check className="h-4 w-4" />
+                            <CheckIcon className="h-4 w-4" />
                         ) : (
-                            <Copy className="h-4 w-4" />
+                            <CopyIcon className="h-4 w-4" />
                         )}
                     </button>
                     <a
@@ -194,7 +194,7 @@ export function GifCard({ gif, compact = false, className }: GifCardProps) {
                         data-tooltip-content="Open in Giphy"
                         onClick={(e) => e.stopPropagation()}
                     >
-                        <ArrowSquareOut className="h-4 w-4" />
+                        <ArrowSquareOutIcon className="h-4 w-4" />
                     </a>
                 </div>
 

--- a/components/generative-ui/notion-page-card.tsx
+++ b/components/generative-ui/notion-page-card.tsx
@@ -7,7 +7,12 @@
  * and last edited date. Links to the actual Notion page.
  */
 
-import { ArrowSquareOut, FileText, Database, Calendar } from "@phosphor-icons/react";
+import {
+    ArrowSquareOutIcon,
+    FileTextIcon,
+    DatabaseIcon,
+    CalendarIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 
@@ -28,7 +33,7 @@ interface NotionPageCardProps {
  * Display a single Notion page/database result as a clickable card.
  */
 export function NotionPageCard({ page, className }: NotionPageCardProps) {
-    const Icon = page.type === "database" ? Database : FileText;
+    const Icon = page.type === "database" ? DatabaseIcon : FileTextIcon;
     const formattedDate = page.last_edited
         ? formatRelativeDate(page.last_edited)
         : null;
@@ -56,7 +61,7 @@ export function NotionPageCard({ page, className }: NotionPageCardProps) {
                         <>
                             <span>·</span>
                             <span className="flex items-center gap-1">
-                                <Calendar className="h-3 w-3" />
+                                <CalendarIcon className="h-3 w-3" />
                                 {formattedDate}
                             </span>
                         </>
@@ -64,7 +69,7 @@ export function NotionPageCard({ page, className }: NotionPageCardProps) {
                 </div>
             </div>
 
-            <ArrowSquareOut className="text-muted-foreground h-4 w-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
+            <ArrowSquareOutIcon className="text-muted-foreground h-4 w-4 shrink-0 opacity-0 transition-opacity group-hover:opacity-100" />
         </a>
     );
 }

--- a/components/generative-ui/tool-debug-panel.tsx
+++ b/components/generative-ui/tool-debug-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Wrench, CaretDown } from "@phosphor-icons/react";
+import { WrenchIcon, CaretDownIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import {
@@ -78,8 +78,8 @@ export function ToolDebugPanel({
                     "hover:bg-muted/30"
                 )}
             >
-                <Wrench className="h-3 w-3" />
-                <CaretDown
+                <WrenchIcon className="h-3 w-3" />
+                <CaretDownIcon
                     className={cn(
                         "h-2.5 w-2.5 transition-transform duration-200",
                         isOpen ? "rotate-180" : "rotate-0"

--- a/components/generative-ui/tool-progress/tool-progress.tsx
+++ b/components/generative-ui/tool-progress/tool-progress.tsx
@@ -12,7 +12,12 @@
  */
 
 import { useMemo } from "react";
-import { Circle, CircleNotch, CheckCircle, XCircle } from "@phosphor-icons/react";
+import {
+    CircleIcon,
+    CircleNotchIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+} from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import type {
     ToolProgressState,
@@ -78,14 +83,14 @@ function DeterminateBar({
 function StepIcon({ status }: { status: ToolProgressStepStatus }) {
     switch (status) {
         case "completed":
-            return <CheckCircle className="size-3.5 text-emerald-500" />;
+            return <CheckCircleIcon className="size-3.5 text-emerald-500" />;
         case "active":
-            return <CircleNotch className="text-primary size-3.5 animate-spin" />;
+            return <CircleNotchIcon className="text-primary size-3.5 animate-spin" />;
         case "error":
-            return <XCircle className="text-destructive size-3.5" />;
+            return <XCircleIcon className="text-destructive size-3.5" />;
         case "pending":
         default:
-            return <Circle className="text-muted-foreground/40 size-3.5" />;
+            return <CircleIcon className="text-muted-foreground/40 size-3.5" />;
     }
 }
 

--- a/components/generative-ui/tool-status-badge.tsx
+++ b/components/generative-ui/tool-status-badge.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Circle, Clock, CheckCircle, XCircle } from "@phosphor-icons/react";
+import {
+    CircleIcon,
+    ClockIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -51,16 +56,18 @@ function StatusIcon({ status }: { status: ToolStatus }) {
 
     switch (status) {
         case "pending":
-            return <Circle className={cn(iconClass, "text-muted-foreground/60")} />;
+            return <CircleIcon className={cn(iconClass, "text-muted-foreground/60")} />;
         case "running":
-            return <Clock className={cn(iconClass, "text-primary/70 animate-pulse")} />;
+            return (
+                <ClockIcon className={cn(iconClass, "text-primary/70 animate-pulse")} />
+            );
         case "completed":
             return (
-                <CheckCircle
+                <CheckCircleIcon
                     className={cn(iconClass, "text-green-600 dark:text-green-400")}
                 />
             );
         case "error":
-            return <XCircle className={cn(iconClass, "text-red-500")} />;
+            return <XCircleIcon className={cn(iconClass, "text-red-500")} />;
     }
 }

--- a/components/generative-ui/tool-status.tsx
+++ b/components/generative-ui/tool-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { ToolIcon } from "./tool-icon";
@@ -101,7 +101,7 @@ export function ToolStatus({
             )}
 
             {/* Expand chevron */}
-            <CaretRight
+            <CaretRightIcon
                 className={cn(
                     "text-muted-foreground/50 h-4 w-4 shrink-0 transition-transform duration-200",
                     expanded && "rotate-90"

--- a/components/generative-ui/tool-wrapper.tsx
+++ b/components/generative-ui/tool-wrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { CaretDown, WarningCircle } from "@phosphor-icons/react";
+import { CaretDownIcon, WarningCircleIcon } from "@phosphor-icons/react";
 import Image from "next/image";
 
 import { cn } from "@/lib/utils";
@@ -251,7 +251,7 @@ export function ToolWrapper({
                         )}
                     >
                         {isError ? (
-                            <WarningCircle className="h-3.5 w-3.5 shrink-0" />
+                            <WarningCircleIcon className="h-3.5 w-3.5 shrink-0" />
                         ) : (
                             renderIcon("sm")
                         )}
@@ -260,7 +260,7 @@ export function ToolWrapper({
                             <span className="animate-pulse text-xs">...</span>
                         )}
                         {status === "completed" && children && (
-                            <CaretDown
+                            <CaretDownIcon
                                 className={cn(
                                     "h-3.5 w-3.5 transition-transform duration-200",
                                     isOpen ? "rotate-180" : "rotate-0"
@@ -312,7 +312,7 @@ export function ToolWrapper({
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                     <ToolStatusBadge status={status} label={statusLabel} />
-                    <CaretDown
+                    <CaretDownIcon
                         className={cn(
                             "text-muted-foreground h-4 w-4 transition-transform duration-200",
                             isOpen ? "rotate-180" : "rotate-0"

--- a/components/generative-ui/web-search.tsx
+++ b/components/generative-ui/web-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowSquareOut, CaretDown, CaretUp } from "@phosphor-icons/react";
+import { ArrowSquareOutIcon, CaretDownIcon, CaretUpIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { glass, border } from "@/lib/design-tokens";
@@ -115,12 +115,12 @@ function SearchResultsList({ results }: { results: SearchResultItem[] }) {
                                     className="text-muted-foreground hover:bg-accent hover:text-foreground rounded p-1 transition-colors"
                                     aria-label={`Open ${item.title} in new tab`}
                                 >
-                                    <ArrowSquareOut className="h-3.5 w-3.5" />
+                                    <ArrowSquareOutIcon className="h-3.5 w-3.5" />
                                 </a>
                                 {isResultExpanded ? (
-                                    <CaretUp className="text-muted-foreground h-4 w-4" />
+                                    <CaretUpIcon className="text-muted-foreground h-4 w-4" />
                                 ) : (
-                                    <CaretDown className="text-muted-foreground h-4 w-4" />
+                                    <CaretDownIcon className="text-muted-foreground h-4 w-4" />
                                 )}
                             </div>
                         </button>

--- a/components/integrations/api-key-modal.tsx
+++ b/components/integrations/api-key-modal.tsx
@@ -2,7 +2,13 @@
 
 import { useState, useActionState } from "react";
 import Image from "next/image";
-import { ArrowSquareOut, CircleNotch, Eye, EyeSlash, Key } from "@phosphor-icons/react";
+import {
+    ArrowSquareOutIcon,
+    CircleNotchIcon,
+    EyeIcon,
+    EyeSlashIcon,
+    KeyIcon,
+} from "@phosphor-icons/react";
 import {
     Dialog,
     DialogContent,
@@ -114,9 +120,9 @@ export function ApiKeyModal({
                                 rel="noopener noreferrer"
                                 className="text-primary decoration-primary/30 hover:decoration-primary inline-flex items-center gap-1.5 text-sm underline transition-colors"
                             >
-                                <Key className="h-3.5 w-3.5" />
+                                <KeyIcon className="h-3.5 w-3.5" />
                                 Get your API key
-                                <ArrowSquareOut className="h-3 w-3" />
+                                <ArrowSquareOutIcon className="h-3 w-3" />
                             </a>
                         </div>
                     )}
@@ -154,9 +160,9 @@ export function ApiKeyModal({
                                 }
                             >
                                 {showKey ? (
-                                    <EyeSlash className="h-4 w-4" />
+                                    <EyeSlashIcon className="h-4 w-4" />
                                 ) : (
-                                    <Eye className="h-4 w-4" />
+                                    <EyeIcon className="h-4 w-4" />
                                 )}
                             </button>
                         </div>
@@ -186,7 +192,7 @@ export function ApiKeyModal({
                         >
                             {isPending ? (
                                 <>
-                                    <CircleNotch className="h-4 w-4 animate-spin" />
+                                    <CircleNotchIcon className="h-4 w-4 animate-spin" />
                                     Connecting...
                                 </>
                             ) : (

--- a/components/integrations/service-card.tsx
+++ b/components/integrations/service-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { Check, WarningCircle, Clock } from "@phosphor-icons/react";
+import { CheckIcon, WarningCircleIcon, ClockIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import type { ServiceDefinition, RolloutStatus } from "@/lib/integrations/services";
 import type { IntegrationStatus } from "@/lib/integrations/types";
@@ -19,7 +19,7 @@ function StatusBadge({ status }: { status: RolloutStatus | IntegrationStatus }) 
     if (status === "connected") {
         return (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-green-500/15 px-3 py-1 text-xs font-medium text-green-700 dark:text-green-400">
-                <Check className="h-3 w-3" />
+                <CheckIcon className="h-3 w-3" />
                 Connected
             </span>
         );
@@ -28,7 +28,7 @@ function StatusBadge({ status }: { status: RolloutStatus | IntegrationStatus }) 
     if (status === "error") {
         return (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-red-500/15 px-3 py-1 text-xs font-medium text-red-700 dark:text-red-400">
-                <WarningCircle className="h-3 w-3" />
+                <WarningCircleIcon className="h-3 w-3" />
                 Error
             </span>
         );
@@ -37,7 +37,7 @@ function StatusBadge({ status }: { status: RolloutStatus | IntegrationStatus }) 
     if (status === "expired") {
         return (
             <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-500/15 px-3 py-1 text-xs font-medium text-amber-700 dark:text-amber-400">
-                <Clock className="h-3 w-3" />
+                <ClockIcon className="h-3 w-3" />
                 Expired
             </span>
         );

--- a/components/integrations/undo-toast.tsx
+++ b/components/integrations/undo-toast.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowUUpLeft } from "@phosphor-icons/react";
+import { ArrowUUpLeftIcon } from "@phosphor-icons/react";
 import type { ServiceDefinition } from "@/lib/integrations/services";
 
 export interface UndoToastProps {
@@ -36,7 +36,7 @@ export function UndoToast({ service, onUndo, visible }: UndoToastProps) {
                             onClick={onUndo}
                             className="flex items-center gap-1.5 rounded-lg bg-white/10 px-3 py-1.5 text-sm font-medium transition-colors hover:bg-white/20"
                         >
-                            <ArrowUUpLeft className="h-3.5 w-3.5" />
+                            <ArrowUUpLeftIcon className="h-3.5 w-3.5" />
                             Undo
                         </button>
                     </div>

--- a/components/knowledge-viewer/kb-page-content.tsx
+++ b/components/knowledge-viewer/kb-page-content.tsx
@@ -9,7 +9,7 @@
 
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { Sparkle, ChatCircle } from "@phosphor-icons/react";
+import { SparkleIcon, ChatCircleIcon } from "@phosphor-icons/react";
 
 import { KnowledgeViewer } from "./index";
 import { LibrarianTaskBar } from "./librarian-task-bar";
@@ -42,7 +42,7 @@ export function KBPageContent({ initialFolders }: KBPageContentProps) {
                     className="glass-card hover:bg-foreground/5 flex items-center gap-2 rounded-xl px-4 py-2.5 transition-colors"
                     title="Open concierge chat"
                 >
-                    <ChatCircle className="text-primary h-5 w-5" weight="duotone" />
+                    <ChatCircleIcon className="text-primary h-5 w-5" weight="duotone" />
                     <span className="hidden text-sm font-medium sm:inline">
                         Search together
                     </span>
@@ -53,7 +53,7 @@ export function KBPageContent({ initialFolders }: KBPageContentProps) {
             <section className="min-h-[500px] flex-1">
                 {initialFolders.length === 0 ? (
                     <div className="border-foreground/5 bg-foreground/[0.02] flex h-full flex-col items-center justify-center rounded-2xl border py-16 text-center">
-                        <Sparkle className="text-foreground/30 mb-4 h-12 w-12" />
+                        <SparkleIcon className="text-foreground/30 mb-4 h-12 w-12" />
                         <h3 className="text-foreground/80 text-lg font-medium">
                             We're setting up your knowledge base
                         </h3>

--- a/components/knowledge-viewer/librarian-task-bar.tsx
+++ b/components/knowledge-viewer/librarian-task-bar.tsx
@@ -15,7 +15,14 @@
 import { useState, useCallback, useRef, useMemo } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
-import { Book, X, CaretDown, CaretUp, Spinner, Check } from "@phosphor-icons/react";
+import {
+    BookIcon,
+    XIcon,
+    CaretDownIcon,
+    CaretUpIcon,
+    SpinnerIcon,
+    CheckIcon,
+} from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { cn } from "@/lib/utils";
@@ -164,7 +171,7 @@ export function LibrarianTaskBar({
             {/* Input row - always visible */}
             <form onSubmit={handleSubmit} className="flex items-center gap-3 p-3">
                 <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-500/10">
-                    <Book className="h-4 w-4 text-violet-500" weight="duotone" />
+                    <BookIcon className="h-4 w-4 text-violet-500" weight="duotone" />
                 </div>
 
                 <input
@@ -184,10 +191,10 @@ export function LibrarianTaskBar({
 
                 {/* Status indicator */}
                 {isLoading && (
-                    <Spinner className="h-4 w-4 animate-spin text-violet-500" />
+                    <SpinnerIcon className="h-4 w-4 animate-spin text-violet-500" />
                 )}
                 {isComplete && (
-                    <Check className="h-4 w-4 text-green-500" weight="bold" />
+                    <CheckIcon className="h-4 w-4 text-green-500" weight="bold" />
                 )}
 
                 {/* Expand/collapse toggle */}
@@ -199,9 +206,9 @@ export function LibrarianTaskBar({
                         aria-label={isExpanded ? "Collapse" : "Expand"}
                     >
                         {isExpanded ? (
-                            <CaretUp className="h-4 w-4" />
+                            <CaretUpIcon className="h-4 w-4" />
                         ) : (
-                            <CaretDown className="h-4 w-4" />
+                            <CaretDownIcon className="h-4 w-4" />
                         )}
                     </button>
                 )}
@@ -214,7 +221,7 @@ export function LibrarianTaskBar({
                         className="text-foreground/40 hover:text-foreground/60 transition-colors"
                         aria-label="Dismiss"
                     >
-                        <X className="h-4 w-4" />
+                        <XIcon className="h-4 w-4" />
                     </button>
                 )}
             </form>
@@ -256,7 +263,7 @@ export function LibrarianTaskBar({
                             {/* Loading state when no content yet */}
                             {isLoading && !responseText && toolParts.length === 0 && (
                                 <p className="text-foreground/50 flex items-center gap-2 text-sm">
-                                    <Spinner className="h-3 w-3 animate-spin" />
+                                    <SpinnerIcon className="h-3 w-3 animate-spin" />
                                     Looking...
                                 </p>
                             )}

--- a/components/pwa/install-prompt.tsx
+++ b/components/pwa/install-prompt.tsx
@@ -26,7 +26,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, House } from "@phosphor-icons/react";
+import { XIcon, HouseIcon } from "@phosphor-icons/react";
 import { logger } from "@/lib/client-logger";
 
 const VISIT_COUNT_KEY = "carmenta-visit-count";
@@ -155,13 +155,13 @@ export function InstallPrompt() {
                             className="text-foreground/40 hover:bg-foreground/10 hover:text-foreground/60 absolute top-1 right-1 flex h-11 w-11 items-center justify-center rounded-full transition-colors active:scale-95"
                             aria-label="Dismiss install prompt"
                         >
-                            <X className="h-4 w-4" />
+                            <XIcon className="h-4 w-4" />
                         </button>
 
                         {/* Header with icon */}
                         <div className="mb-4 flex items-center gap-3">
                             <div className="from-primary/20 to-primary/10 flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-gradient-to-br">
-                                <House className="text-primary h-6 w-6" />
+                                <HouseIcon className="text-primary h-6 w-6" />
                             </div>
                             <div>
                                 <h3 className="text-foreground font-semibold">

--- a/components/pwa/pull-to-refresh-indicator.tsx
+++ b/components/pwa/pull-to-refresh-indicator.tsx
@@ -11,7 +11,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { CircleNotch } from "@phosphor-icons/react";
+import { CircleNotchIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 interface PullToRefreshIndicatorProps {
@@ -59,7 +59,7 @@ export function PullToRefreshIndicator({
                         : "text-foreground/70 border border-white/20 bg-white/20 dark:bg-white/10"
                 )}
             >
-                <CircleNotch
+                <CircleNotchIcon
                     className={cn("h-5 w-5", isRefreshing && "animate-spin")}
                     style={{
                         opacity: isRefreshing ? 1 : 0.4 + progress * 0.6,

--- a/components/pwa/swipe-back-indicator.tsx
+++ b/components/pwa/swipe-back-indicator.tsx
@@ -10,7 +10,7 @@
 "use client";
 
 import { motion, AnimatePresence } from "framer-motion";
-import { CaretLeft } from "@phosphor-icons/react";
+import { CaretLeftIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 interface SwipeBackIndicatorProps {
@@ -50,7 +50,7 @@ export function SwipeBackIndicator({
                                 : "bg-background/80 text-foreground/60"
                         )}
                     >
-                        <CaretLeft
+                        <CaretLeftIcon
                             className={cn(
                                 "h-6 w-6 transition-transform",
                                 isTriggered && "scale-110"

--- a/components/tool-ui/option-list/option-list.tsx
+++ b/components/tool-ui/option-list/option-list.tsx
@@ -6,7 +6,7 @@ import type { OptionListProps, OptionListSelection, OptionListOption } from "./s
 import { ActionButtons, normalizeActionsConfig } from "../shared";
 import type { Action } from "../shared";
 import { cn, Button, Separator } from "./_adapter";
-import { Check } from "@phosphor-icons/react";
+import { CheckIcon } from "@phosphor-icons/react";
 import { glass, border } from "@/lib/design-tokens";
 
 function parseSelectionToIdSet(
@@ -63,7 +63,7 @@ function SelectionIndicator({ mode, isSelected, disabled }: SelectionIndicatorPr
                 disabled && "opacity-50"
             )}
         >
-            {mode === "multi" && isSelected && <Check className="size-3" />}
+            {mode === "multi" && isSelected && <CheckIcon className="size-3" />}
             {mode === "single" && isSelected && (
                 <span className="size-2 rounded-full bg-current" />
             )}
@@ -186,7 +186,7 @@ function OptionListConfirmation({
                         {index > 0 && <Separator orientation="horizontal" />}
                         <div className="flex items-start gap-3 py-1">
                             <span className="flex h-6 items-center">
-                                <Check className="text-primary size-4 shrink-0" />
+                                <CheckIcon className="text-primary size-4 shrink-0" />
                             </span>
                             {option.icon && (
                                 <span className="flex h-6 items-center">

--- a/components/tools/code/agent-task.tsx
+++ b/components/tools/code/agent-task.tsx
@@ -7,7 +7,12 @@
  * to handle complex work. Shows agent type, description, and result.
  */
 
-import { Robot, CheckCircle, WarningCircle, CircleNotch } from "@phosphor-icons/react";
+import {
+    RobotIcon,
+    CheckCircleIcon,
+    WarningCircleIcon,
+    CircleNotchIcon,
+} from "@phosphor-icons/react";
 import { useState } from "react";
 
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -83,11 +88,11 @@ export function AgentTask({
             >
                 {/* Status icon */}
                 {isRunning ? (
-                    <CircleNotch className="h-4 w-4 animate-spin text-purple-400" />
+                    <CircleNotchIcon className="h-4 w-4 animate-spin text-purple-400" />
                 ) : status === "error" ? (
-                    <WarningCircle className="h-4 w-4 text-red-400" />
+                    <WarningCircleIcon className="h-4 w-4 text-red-400" />
                 ) : (
-                    <Robot className="h-4 w-4 text-purple-400" />
+                    <RobotIcon className="h-4 w-4 text-purple-400" />
                 )}
 
                 {/* Agent info */}
@@ -97,7 +102,7 @@ export function AgentTask({
                             {displayName}
                         </span>
                         {status === "completed" && (
-                            <CheckCircle className="h-3.5 w-3.5 text-green-400" />
+                            <CheckCircleIcon className="h-3.5 w-3.5 text-green-400" />
                         )}
                     </div>
                     {description && (

--- a/components/tools/code/ask-user-question.tsx
+++ b/components/tools/code/ask-user-question.tsx
@@ -14,7 +14,7 @@
 
 import { useState, useCallback } from "react";
 import { motion } from "framer-motion";
-import { PaperPlaneTilt, ChatCircle, Check } from "@phosphor-icons/react";
+import { PaperPlaneTiltIcon, ChatCircleIcon, CheckIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -120,7 +120,7 @@ function QuestionBlock({
                                     )}
                                 >
                                     {isSelected && (
-                                        <Check className="h-3 w-3 text-white" />
+                                        <CheckIcon className="h-3 w-3 text-white" />
                                     )}
                                 </span>
                             )}
@@ -156,7 +156,7 @@ function QuestionBlock({
                         size="sm"
                         className="bg-purple-600 hover:bg-purple-500"
                     >
-                        <PaperPlaneTilt className="mr-1.5 h-3.5 w-3.5" />
+                        <PaperPlaneTiltIcon className="mr-1.5 h-3.5 w-3.5" />
                         Confirm selection
                     </Button>
                 </motion.div>
@@ -217,7 +217,7 @@ function OtherInput({
                     size="icon"
                     className="h-[60px] w-[60px] bg-purple-600 hover:bg-purple-500"
                 >
-                    <PaperPlaneTilt className="h-4 w-4" />
+                    <PaperPlaneTiltIcon className="h-4 w-4" />
                 </Button>
             </div>
         </div>
@@ -316,7 +316,7 @@ export function AskUserQuestion({
     if (status === "running") {
         return (
             <div className="my-2 flex items-center gap-2 rounded-lg border border-purple-500/20 bg-purple-500/5 px-3 py-2">
-                <ChatCircle className="h-4 w-4 animate-pulse text-purple-400" />
+                <ChatCircleIcon className="h-4 w-4 animate-pulse text-purple-400" />
                 <span className="text-muted-foreground text-sm">
                     Preparing question...
                 </span>
@@ -349,11 +349,11 @@ export function AskUserQuestion({
         >
             {/* Header bar */}
             <div className="flex items-center gap-2 border-b border-purple-500/10 bg-purple-500/10 px-3 py-2">
-                <ChatCircle className="h-4 w-4 text-purple-400" />
+                <ChatCircleIcon className="h-4 w-4 text-purple-400" />
                 <span className="text-sm font-medium text-purple-200">Question</span>
                 {answeredQuestions.size > 0 && (
                     <span className="ml-auto flex items-center gap-1 text-xs text-green-400">
-                        <Check className="h-3 w-3" />
+                        <CheckIcon className="h-3 w-3" />
                         {answeredQuestions.size} of {input.questions.length} answered
                     </span>
                 )}

--- a/components/tools/code/diff-viewer.tsx
+++ b/components/tools/code/diff-viewer.tsx
@@ -14,15 +14,15 @@
 
 import { useMemo, useState, useCallback } from "react";
 import {
-    PencilSimpleLine,
-    Minus,
-    Plus,
-    ArrowRight,
-    Copy,
-    Check,
-    CaretDown,
-    CaretUp,
-    CircleNotch,
+    PencilSimpleLineIcon,
+    MinusIcon,
+    PlusIcon,
+    ArrowRightIcon,
+    CopyIcon,
+    CheckIcon,
+    CaretDownIcon,
+    CaretUpIcon,
+    CircleNotchIcon,
 } from "@phosphor-icons/react";
 import ReactDiffViewer, { DiffMethod } from "react-diff-viewer-continued";
 import { useTheme } from "next-themes";
@@ -266,7 +266,7 @@ export function DiffViewer({
             {/* Header */}
             <div className="border-border bg-muted/50 flex items-center justify-between border-b px-3 py-2">
                 <div className="flex items-center gap-2 overflow-hidden">
-                    <PencilSimpleLine className="h-4 w-4 shrink-0 text-amber-500" />
+                    <PencilSimpleLineIcon className="h-4 w-4 shrink-0 text-amber-500" />
                     <span className="text-foreground truncate font-mono text-sm">
                         {fileName}
                     </span>
@@ -285,7 +285,7 @@ export function DiffViewer({
                 <div className="flex items-center gap-2">
                     {/* Loading indicator */}
                     {isRunning && (
-                        <CircleNotch className="text-muted-foreground h-4 w-4 animate-spin" />
+                        <CircleNotchIcon className="text-muted-foreground h-4 w-4 animate-spin" />
                     )}
 
                     {/* Copy new content */}
@@ -296,9 +296,9 @@ export function DiffViewer({
                             aria-label="Copy new content"
                         >
                             {isCopied ? (
-                                <Check className="h-4 w-4 text-green-500" />
+                                <CheckIcon className="h-4 w-4 text-green-500" />
                             ) : (
-                                <Copy className="h-4 w-4" />
+                                <CopyIcon className="h-4 w-4" />
                             )}
                         </button>
                     )}
@@ -319,13 +319,13 @@ export function DiffViewer({
                 <div className="border-border bg-muted/20 flex items-center gap-3 border-b px-3 py-1.5 text-xs">
                     {deletions > 0 && (
                         <span className="flex items-center gap-1 text-red-500">
-                            <Minus className="h-3 w-3" />
+                            <MinusIcon className="h-3 w-3" />
                             {deletions}
                         </span>
                     )}
                     {additions > 0 && (
                         <span className="flex items-center gap-1 text-green-500">
-                            <Plus className="h-3 w-3" />
+                            <PlusIcon className="h-3 w-3" />
                             {additions}
                         </span>
                     )}
@@ -340,7 +340,7 @@ export function DiffViewer({
                 {/* Loading state */}
                 {isRunning && (
                     <div className="text-muted-foreground flex items-center gap-2 p-4">
-                        <PencilSimpleLine className="h-4 w-4 animate-pulse" />
+                        <PencilSimpleLineIcon className="h-4 w-4 animate-pulse" />
                         <span className="text-sm">Editing file...</span>
                     </div>
                 )}
@@ -356,7 +356,7 @@ export function DiffViewer({
                                     <code className="rounded bg-red-100 px-2 py-1 text-red-700 line-through dark:bg-red-900/30 dark:text-red-300">
                                         {oldContent || "(empty)"}
                                     </code>
-                                    <ArrowRight className="text-muted-foreground h-4 w-4 shrink-0" />
+                                    <ArrowRightIcon className="text-muted-foreground h-4 w-4 shrink-0" />
                                     <code className="rounded bg-green-100 px-2 py-1 text-green-700 dark:bg-green-900/30 dark:text-green-300">
                                         {newContent || "(empty)"}
                                     </code>
@@ -415,7 +415,7 @@ export function DiffViewer({
                 >
                     {!isExpanded ? (
                         <>
-                            <CaretDown className="h-4 w-4" />
+                            <CaretDownIcon className="h-4 w-4" />
                             Show full diff
                             <span className="text-muted-foreground/60">
                                 ({additions + deletions} changes)
@@ -423,7 +423,7 @@ export function DiffViewer({
                         </>
                     ) : (
                         <>
-                            <CaretUp className="h-4 w-4" />
+                            <CaretUpIcon className="h-4 w-4" />
                             Collapse
                         </>
                     )}

--- a/components/tools/code/file-writer.tsx
+++ b/components/tools/code/file-writer.tsx
@@ -14,14 +14,14 @@
 
 import { useState, useMemo, useCallback } from "react";
 import {
-    FilePlus,
-    CheckCircle,
-    Copy,
-    Check,
-    CaretDown,
-    CaretUp,
-    CircleNotch,
-    GitDiff,
+    FilePlusIcon,
+    CheckCircleIcon,
+    CopyIcon,
+    CheckIcon,
+    CaretDownIcon,
+    CaretUpIcon,
+    CircleNotchIcon,
+    GitDiffIcon,
 } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
@@ -175,9 +175,9 @@ export function FileWriter({
             <div className="border-border bg-muted/50 flex items-center justify-between border-b px-3 py-2">
                 <div className="flex items-center gap-2 overflow-hidden">
                     {isCompleted && !error ? (
-                        <CheckCircle className="h-4 w-4 shrink-0 text-green-500" />
+                        <CheckCircleIcon className="h-4 w-4 shrink-0 text-green-500" />
                     ) : (
-                        <FilePlus className="text-muted-foreground h-4 w-4 shrink-0" />
+                        <FilePlusIcon className="text-muted-foreground h-4 w-4 shrink-0" />
                     )}
                     <span className="text-foreground truncate font-mono text-sm">
                         {fileName}
@@ -192,7 +192,7 @@ export function FileWriter({
                 <div className="flex items-center gap-2">
                     {/* Loading indicator */}
                     {isRunning && (
-                        <CircleNotch className="text-muted-foreground h-4 w-4 animate-spin" />
+                        <CircleNotchIcon className="text-muted-foreground h-4 w-4 animate-spin" />
                     )}
 
                     {/* Show diff button - on demand comparison to git HEAD */}
@@ -204,9 +204,9 @@ export function FileWriter({
                             aria-label="Show diff against previous version"
                         >
                             {isLoadingDiff ? (
-                                <CircleNotch className="h-3 w-3 animate-spin" />
+                                <CircleNotchIcon className="h-3 w-3 animate-spin" />
                             ) : (
-                                <GitDiff className="h-3 w-3" />
+                                <GitDiffIcon className="h-3 w-3" />
                             )}
                             <span>Show diff</span>
                         </button>
@@ -230,9 +230,9 @@ export function FileWriter({
                             aria-label="Copy content"
                         >
                             {isCopied ? (
-                                <Check className="h-4 w-4 text-green-500" />
+                                <CheckIcon className="h-4 w-4 text-green-500" />
                             ) : (
-                                <Copy className="h-4 w-4" />
+                                <CopyIcon className="h-4 w-4" />
                             )}
                         </button>
                     )}
@@ -262,7 +262,7 @@ export function FileWriter({
                 {/* Loading state */}
                 {isRunning && (
                     <div className="text-muted-foreground flex items-center gap-2 p-4">
-                        <FilePlus className="h-4 w-4 animate-pulse" />
+                        <FilePlusIcon className="h-4 w-4 animate-pulse" />
                         <span className="text-sm">Writing file...</span>
                     </div>
                 )}
@@ -272,7 +272,7 @@ export function FileWriter({
                     <div className="p-2">
                         {isNewFile ? (
                             <div className="text-muted-foreground flex items-center gap-2 px-2 py-3 text-sm">
-                                <FilePlus className="h-4 w-4 text-green-500" />
+                                <FilePlusIcon className="h-4 w-4 text-green-500" />
                                 <span>New file - no previous version to compare</span>
                             </div>
                         ) : (
@@ -321,12 +321,12 @@ export function FileWriter({
                 >
                     {isCollapsed ? (
                         <>
-                            <CaretDown className="h-4 w-4" />
+                            <CaretDownIcon className="h-4 w-4" />
                             Show all {lineCount} lines
                         </>
                     ) : (
                         <>
-                            <CaretUp className="h-4 w-4" />
+                            <CaretUpIcon className="h-4 w-4" />
                             Collapse
                         </>
                     )}

--- a/components/tools/code/inline-tool-activity.tsx
+++ b/components/tools/code/inline-tool-activity.tsx
@@ -18,7 +18,7 @@
 
 import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { CaretRight, CaretDown } from "@phosphor-icons/react";
+import { CaretRightIcon, CaretDownIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { ToolIcon } from "../shared";
@@ -374,9 +374,9 @@ function ToolActivityRow({ part }: { part: ToolPart }) {
 
                 {/* Expand chevron */}
                 {expanded ? (
-                    <CaretDown className="text-muted-foreground/40 h-3.5 w-3.5 shrink-0" />
+                    <CaretDownIcon className="text-muted-foreground/40 h-3.5 w-3.5 shrink-0" />
                 ) : (
-                    <CaretRight className="text-muted-foreground/40 group-hover:text-muted-foreground/60 h-3.5 w-3.5 shrink-0" />
+                    <CaretRightIcon className="text-muted-foreground/40 group-hover:text-muted-foreground/60 h-3.5 w-3.5 shrink-0" />
                 )}
             </button>
 

--- a/components/tools/code/tool-activity-item.tsx
+++ b/components/tools/code/tool-activity-item.tsx
@@ -16,7 +16,7 @@
 
 import { useState } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { ToolIcon } from "../shared";
@@ -127,7 +127,7 @@ export function ToolActivityItem({
                 )}
 
                 {/* Expand chevron */}
-                <CaretRight
+                <CaretRightIcon
                     className={cn(
                         "text-muted-foreground/40 h-4 w-4 shrink-0 transition-transform duration-200",
                         "group-hover:text-muted-foreground/60",

--- a/components/tools/post-response/acknowledge.tsx
+++ b/components/tools/post-response/acknowledge.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Heart, Sparkle, Confetti } from "@phosphor-icons/react";
+import { HeartIcon, SparkleIcon, ConfettiIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -16,19 +16,19 @@ interface AcknowledgeResultProps {
 
 const typeConfig = {
     gratitude: {
-        icon: Heart,
+        icon: HeartIcon,
         bg: "bg-holo-mint/20",
         border: "border-l-emerald-400/50",
         iconColor: "text-emerald-500",
     },
     encouragement: {
-        icon: Sparkle,
+        icon: SparkleIcon,
         bg: "bg-holo-lavender/20",
         border: "border-l-violet-400/50",
         iconColor: "text-violet-500",
     },
     celebration: {
-        icon: Confetti,
+        icon: ConfettiIcon,
         bg: "bg-holo-gold/20",
         border: "border-l-amber-400/50",
         iconColor: "text-amber-500",

--- a/components/tools/research/deep-research.tsx
+++ b/components/tools/research/deep-research.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState } from "react";
 
 import { motion, AnimatePresence } from "framer-motion";
 import {
-    BookOpen,
-    ArrowSquareOut,
-    WarningCircle,
-    CheckCircle,
-    Question,
+    BookOpenIcon,
+    ArrowSquareOutIcon,
+    WarningCircleIcon,
+    CheckCircleIcon,
+    QuestionIcon,
 } from "@phosphor-icons/react";
 
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -81,7 +81,7 @@ function ResearchInProgress({
 
             {/* Header */}
             <div className="relative flex items-center gap-2">
-                <BookOpen className="text-primary h-4 w-4 animate-pulse" />
+                <BookOpenIcon className="text-primary h-4 w-4 animate-pulse" />
                 <span className="text-foreground text-sm">
                     Conducting {depthLabel} research...
                 </span>
@@ -166,11 +166,11 @@ interface DeepResearchResultProps {
 const ConfidenceIcon = ({ confidence }: { confidence: string }) => {
     switch (confidence) {
         case "high":
-            return <CheckCircle className="h-3 w-3 text-green-500" />;
+            return <CheckCircleIcon className="h-3 w-3 text-green-500" />;
         case "medium":
-            return <Question className="h-3 w-3 text-yellow-500" />;
+            return <QuestionIcon className="h-3 w-3 text-yellow-500" />;
         default:
-            return <Question className="text-muted-foreground h-3 w-3" />;
+            return <QuestionIcon className="text-muted-foreground h-3 w-3" />;
     }
 };
 
@@ -198,7 +198,7 @@ export function DeepResearchResult({
         return (
             <div className="glass-card border-destructive/50 bg-destructive/10 max-w-2xl">
                 <div className="flex items-center gap-2">
-                    <WarningCircle className="text-destructive h-4 w-4" />
+                    <WarningCircleIcon className="text-destructive h-4 w-4" />
                     <p className="text-destructive text-sm">
                         {error || "Research didn't complete. Try again?"}
                     </p>
@@ -214,7 +214,7 @@ export function DeepResearchResult({
     return (
         <div className="glass-card max-w-2xl">
             <div className="flex items-center gap-2">
-                <BookOpen className="text-primary h-4 w-4" />
+                <BookOpenIcon className="text-primary h-4 w-4" />
                 <span className="text-foreground font-medium">Research Complete</span>
             </div>
 
@@ -260,7 +260,7 @@ export function DeepResearchResult({
                                     className="group text-muted-foreground hover:text-primary flex items-center gap-1 text-xs"
                                 >
                                     <span className="truncate">{source.title}</span>
-                                    <ArrowSquareOut className="h-2.5 w-2.5 flex-shrink-0 opacity-0 group-hover:opacity-100" />
+                                    <ArrowSquareOutIcon className="h-2.5 w-2.5 flex-shrink-0 opacity-0 group-hover:opacity-100" />
                                 </a>
                             </li>
                         ))}

--- a/components/tools/research/fetch-page.tsx
+++ b/components/tools/research/fetch-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { FileText, ArrowSquareOut } from "@phosphor-icons/react";
+import { FileTextIcon, ArrowSquareOutIcon } from "@phosphor-icons/react";
 
 import type { ToolStatus } from "@/lib/tools/tool-config";
 import { ToolRenderer } from "../shared";
@@ -65,7 +65,7 @@ function FetchPageContent({
         <div className="max-w-2xl">
             <div className="flex items-start justify-between gap-2">
                 <div className="flex items-center gap-2">
-                    <FileText className="text-primary h-4 w-4" />
+                    <FileTextIcon className="text-primary h-4 w-4" />
                     <span className="text-foreground font-medium">
                         {title || "Page Content"}
                     </span>
@@ -77,7 +77,7 @@ function FetchPageContent({
                     className="text-muted-foreground hover:text-primary flex items-center gap-1 text-xs"
                 >
                     <span className="hidden sm:inline">Open</span>
-                    <ArrowSquareOut className="h-3 w-3" />
+                    <ArrowSquareOutIcon className="h-3 w-3" />
                 </a>
             </div>
 

--- a/components/tools/research/web-search.tsx
+++ b/components/tools/research/web-search.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { ArrowSquareOut, CaretDown, CaretUp } from "@phosphor-icons/react";
+import { ArrowSquareOutIcon, CaretDownIcon, CaretUpIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { glass, border } from "@/lib/design-tokens";
@@ -115,12 +115,12 @@ function SearchResultsList({ results }: { results: SearchResultItem[] }) {
                                     className="text-muted-foreground hover:bg-accent hover:text-foreground rounded p-1 transition-colors"
                                     aria-label={`Open ${item.title} in new tab`}
                                 >
-                                    <ArrowSquareOut className="h-3.5 w-3.5" />
+                                    <ArrowSquareOutIcon className="h-3.5 w-3.5" />
                                 </a>
                                 {isResultExpanded ? (
-                                    <CaretUp className="text-muted-foreground h-4 w-4" />
+                                    <CaretUpIcon className="text-muted-foreground h-4 w-4" />
                                 ) : (
-                                    <CaretDown className="text-muted-foreground h-4 w-4" />
+                                    <CaretDownIcon className="text-muted-foreground h-4 w-4" />
                                 )}
                             </div>
                         </button>

--- a/components/tools/shared/tool-debug-panel.tsx
+++ b/components/tools/shared/tool-debug-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Wrench, CaretDown } from "@phosphor-icons/react";
+import { WrenchIcon, CaretDownIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import {
@@ -78,8 +78,8 @@ export function ToolDebugPanel({
                     "hover:bg-muted/30"
                 )}
             >
-                <Wrench className="h-3 w-3" />
-                <CaretDown
+                <WrenchIcon className="h-3 w-3" />
+                <CaretDownIcon
                     className={cn(
                         "h-2.5 w-2.5 transition-transform duration-200",
                         isOpen ? "rotate-180" : "rotate-0"

--- a/components/tools/shared/tool-status-badge.tsx
+++ b/components/tools/shared/tool-status-badge.tsx
@@ -1,6 +1,11 @@
 "use client";
 
-import { Circle, Clock, CheckCircle, XCircle } from "@phosphor-icons/react";
+import {
+    CircleIcon,
+    ClockIcon,
+    CheckCircleIcon,
+    XCircleIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import type { ToolStatus } from "@/lib/tools/tool-config";
@@ -51,16 +56,18 @@ function StatusIcon({ status }: { status: ToolStatus }) {
 
     switch (status) {
         case "pending":
-            return <Circle className={cn(iconClass, "text-muted-foreground/60")} />;
+            return <CircleIcon className={cn(iconClass, "text-muted-foreground/60")} />;
         case "running":
-            return <Clock className={cn(iconClass, "text-primary/70 animate-pulse")} />;
+            return (
+                <ClockIcon className={cn(iconClass, "text-primary/70 animate-pulse")} />
+            );
         case "completed":
             return (
-                <CheckCircle
+                <CheckCircleIcon
                     className={cn(iconClass, "text-green-600 dark:text-green-400")}
                 />
             );
         case "error":
-            return <XCircle className={cn(iconClass, "text-red-500")} />;
+            return <XCircleIcon className={cn(iconClass, "text-red-500")} />;
     }
 }

--- a/components/tools/shared/tool-status.tsx
+++ b/components/tools/shared/tool-status.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { CaretRight } from "@phosphor-icons/react";
+import { CaretRightIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { ToolIcon } from "./tool-icon";
@@ -101,7 +101,7 @@ export function ToolStatus({
             )}
 
             {/* Expand chevron */}
-            <CaretRight
+            <CaretRightIcon
                 className={cn(
                     "text-muted-foreground/50 h-4 w-4 shrink-0 transition-transform duration-200",
                     expanded && "rotate-90"

--- a/components/tools/shared/tool-wrapper.tsx
+++ b/components/tools/shared/tool-wrapper.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { CaretDown, WarningCircle } from "@phosphor-icons/react";
+import { CaretDownIcon, WarningCircleIcon } from "@phosphor-icons/react";
 import Image from "next/image";
 
 import { cn } from "@/lib/utils";
@@ -251,7 +251,7 @@ export function ToolWrapper({
                         )}
                     >
                         {isError ? (
-                            <WarningCircle className="h-3.5 w-3.5 shrink-0" />
+                            <WarningCircleIcon className="h-3.5 w-3.5 shrink-0" />
                         ) : (
                             renderIcon("sm")
                         )}
@@ -260,7 +260,7 @@ export function ToolWrapper({
                             <span className="animate-pulse text-xs">...</span>
                         )}
                         {status === "completed" && children && (
-                            <CaretDown
+                            <CaretDownIcon
                                 className={cn(
                                     "h-3.5 w-3.5 transition-transform duration-200",
                                     isOpen ? "rotate-180" : "rotate-0"
@@ -312,7 +312,7 @@ export function ToolWrapper({
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
                     <ToolStatusBadge status={status} label={statusLabel} />
-                    <CaretDown
+                    <CaretDownIcon
                         className={cn(
                             "text-muted-foreground h-4 w-4 transition-transform duration-200",
                             isOpen ? "rotate-180" : "rotate-0"

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-import { CaretDown } from "@phosphor-icons/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 
@@ -34,7 +34,7 @@ const AccordionTrigger = React.forwardRef<
             {...props}
         >
             {children}
-            <CaretDown className="text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200" />
+            <CaretDownIcon className="text-muted-foreground h-4 w-4 shrink-0 transition-transform duration-200" />
         </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
 ));

--- a/components/ui/chat-return-nav.tsx
+++ b/components/ui/chat-return-nav.tsx
@@ -15,7 +15,7 @@
 
 import Link from "next/link";
 import { motion, AnimatePresence } from "framer-motion";
-import { ArrowLeft, ChatCircle } from "@phosphor-icons/react";
+import { ArrowLeftIcon, ChatCircleIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { useLastConnection } from "@/lib/hooks/use-last-connection";
@@ -60,7 +60,7 @@ export function ChatReturnNav({ className, compact = false }: ChatReturnNavProps
                             compact ? "px-2.5 py-1.5 text-xs" : "px-3 py-1.5 text-sm"
                         )}
                     >
-                        <ArrowLeft
+                        <ArrowLeftIcon
                             className={cn(
                                 "transition-transform group-hover:-translate-x-0.5",
                                 compact ? "h-3 w-3" : "h-3.5 w-3.5"
@@ -78,7 +78,7 @@ export function ChatReturnNav({ className, compact = false }: ChatReturnNavProps
                                 </span>
                             ) : (
                                 <>
-                                    <ChatCircle
+                                    <ChatCircleIcon
                                         className={compact ? "h-3 w-3" : "h-3.5 w-3.5"}
                                     />
                                     <span className="font-medium">Back to chat</span>

--- a/components/ui/copy-button.tsx
+++ b/components/ui/copy-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { Copy, Check, CaretDown } from "@phosphor-icons/react";
+import { CopyIcon, CheckIcon, CaretDownIcon } from "@phosphor-icons/react";
 import { motion } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { transitions } from "@/lib/motion/presets";
@@ -248,7 +248,7 @@ export function CopyButton({
             >
                 {copied ? (
                     <>
-                        <Check className={cn(iconSize, "flex-shrink-0")} />
+                        <CheckIcon className={cn(iconSize, "flex-shrink-0")} />
                         <motion.span
                             initial={{ opacity: 0, width: 0 }}
                             animate={{ opacity: 1, width: "auto" }}
@@ -261,7 +261,7 @@ export function CopyButton({
                         </motion.span>
                     </>
                 ) : (
-                    <Copy className={iconSize} />
+                    <CopyIcon className={iconSize} />
                 )}
             </motion.button>
         );
@@ -284,7 +284,7 @@ export function CopyButton({
                 >
                     {copied ? (
                         <>
-                            <Check className={cn(iconSize, "flex-shrink-0")} />
+                            <CheckIcon className={cn(iconSize, "flex-shrink-0")} />
                             <motion.span
                                 initial={{ opacity: 0, width: 0 }}
                                 animate={{ opacity: 1, width: "auto" }}
@@ -297,7 +297,7 @@ export function CopyButton({
                             </motion.span>
                         </>
                     ) : (
-                        <Copy className={iconSize} />
+                        <CopyIcon className={iconSize} />
                     )}
                 </motion.button>
 
@@ -310,7 +310,7 @@ export function CopyButton({
                             "rounded-r-md border-l border-white/20 px-1"
                         )}
                     >
-                        <CaretDown className={chevronSize} />
+                        <CaretDownIcon className={chevronSize} />
                     </button>
                 </DropdownMenuTrigger>
             </div>

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { X } from "@phosphor-icons/react";
+import { XIcon } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 
@@ -45,7 +45,7 @@ const DialogContent = React.forwardRef<
         >
             {children}
             <DialogPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 flex h-11 w-11 items-center justify-center rounded-full opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-none disabled:pointer-events-none">
-                <X className="h-5 w-5" />
+                <XIcon className="h-5 w-5" />
                 <span className="sr-only">Close</span>
             </DialogPrimitive.Close>
         </DialogPrimitive.Content>

--- a/components/ui/expandable-text.tsx
+++ b/components/ui/expandable-text.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useRef, useLayoutEffect, type ReactNode } from "react";
-import { CaretDown } from "@phosphor-icons/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 
 /**
@@ -126,7 +126,7 @@ export function ExpandableText({
                     "focus:ring-primary/60 focus:ring-2 focus:outline-none"
                 )}
             >
-                <CaretDown
+                <CaretDownIcon
                     className={cn(
                         "h-4 w-4 text-white transition-transform duration-300",
                         isExpanded && "rotate-180"

--- a/components/ui/feature-tip.tsx
+++ b/components/ui/feature-tip.tsx
@@ -16,7 +16,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, Sparkle, ArrowRight } from "@phosphor-icons/react";
+import { XIcon, SparkleIcon, ArrowRightIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 
 import { cn } from "@/lib/utils";
@@ -79,7 +79,7 @@ export function FeatureTip({ className }: FeatureTipProps) {
                             <div className="mb-2 flex items-start justify-between gap-3">
                                 <div className="flex items-center gap-2">
                                     <div className="bg-primary/10 flex h-7 w-7 shrink-0 items-center justify-center rounded-full">
-                                        <Sparkle className="text-primary h-3.5 w-3.5" />
+                                        <SparkleIcon className="text-primary h-3.5 w-3.5" />
                                     </div>
                                     <h3 className="text-foreground/90 text-sm font-semibold">
                                         {tip.tipTitle}
@@ -92,7 +92,7 @@ export function FeatureTip({ className }: FeatureTipProps) {
                                     className="text-foreground/40 hover:bg-foreground/10 hover:text-foreground/60 focus-visible:bg-foreground/10 focus-visible:text-foreground/60 focus-visible:ring-primary/50 flex h-6 w-6 shrink-0 items-center justify-center rounded-full transition-colors focus:outline-none focus-visible:ring-2"
                                     aria-label="Dismiss tip"
                                 >
-                                    <X className="h-3.5 w-3.5" />
+                                    <XIcon className="h-3.5 w-3.5" />
                                 </button>
                             </div>
 
@@ -138,7 +138,7 @@ export function FeatureTip({ className }: FeatureTipProps) {
                                             className="btn-glass-interactive text-foreground/80 hover:text-foreground inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-colors"
                                         >
                                             {tip.cta.label}
-                                            <ArrowRight className="h-3.5 w-3.5" />
+                                            <ArrowRightIcon className="h-3.5 w-3.5" />
                                         </Link>
                                     )}
                                     {tip.cta.action === "settings" && (
@@ -148,7 +148,7 @@ export function FeatureTip({ className }: FeatureTipProps) {
                                             className="btn-glass-interactive text-foreground/80 hover:text-foreground inline-flex items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-colors"
                                         >
                                             {tip.cta.label}
-                                            <ArrowRight className="h-3.5 w-3.5" />
+                                            <ArrowRightIcon className="h-3.5 w-3.5" />
                                         </button>
                                     )}
                                 </div>

--- a/components/ui/freeform-input.tsx
+++ b/components/ui/freeform-input.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { PaperPlaneTilt } from "@phosphor-icons/react";
+import { PaperPlaneTiltIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
@@ -49,7 +49,7 @@ export function FreeformInput({
                 size="icon"
                 className="h-[60px] w-[60px]"
             >
-                <PaperPlaneTilt className="h-4 w-4" />
+                <PaperPlaneTiltIcon className="h-4 w-4" />
             </Button>
         </div>
     );

--- a/components/ui/oracle-menu.tsx
+++ b/components/ui/oracle-menu.tsx
@@ -20,18 +20,18 @@ import Link from "next/link";
 import Image from "next/image";
 import { AnimatePresence, motion } from "framer-motion";
 import {
-    Plus,
-    Users,
-    Compass,
-    Heart,
-    Code,
-    GithubLogo,
-    Shield,
-    FileText,
-    Lock,
-    ArrowSquareOut,
-    House,
-    Sparkle,
+    PlusIcon,
+    UsersIcon,
+    CompassIcon,
+    HeartIcon,
+    CodeIcon,
+    GithubLogoIcon,
+    ShieldIcon,
+    FileTextIcon,
+    LockIcon,
+    ArrowSquareOutIcon,
+    HouseIcon,
+    SparkleIcon,
 } from "@phosphor-icons/react";
 
 import { useCarmentaModal } from "@/hooks/use-carmenta-modal";
@@ -165,7 +165,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <House className="text-foreground/60 relative h-4 w-4" />
+                                          <HouseIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">Home</span>
                                       </Link>
 
@@ -176,7 +176,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                           className="group text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium transition-all"
                                       >
                                           <div className="bg-primary/10 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <Plus className="text-primary relative h-4 w-4" />
+                                          <PlusIcon className="text-primary relative h-4 w-4" />
                                           <span className="relative">
                                               New Connection
                                           </span>
@@ -192,7 +192,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                       >
                                           <div className="bg-primary/10 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
                                           <span className="relative flex items-center gap-3">
-                                              <Sparkle
+                                              <SparkleIcon
                                                   className="text-primary h-4 w-4"
                                                   weight="duotone"
                                               />
@@ -208,7 +208,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                       {/* Carmenta Features */}
                                       <div className="text-foreground/40 flex w-full cursor-not-allowed items-center justify-between px-4 py-2.5 text-sm">
                                           <span className="flex items-center gap-3">
-                                              <Users className="h-4 w-4" />
+                                              <UsersIcon className="h-4 w-4" />
                                               AI Team
                                           </span>
                                           <span className="bg-foreground/5 text-foreground/50 rounded-full px-2 py-0.5 text-[10px] font-medium">
@@ -222,7 +222,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <Compass className="text-foreground/60 relative h-4 w-4" />
+                                          <CompassIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">Guide</span>
                                       </Link>
 
@@ -235,7 +235,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <Heart
+                                          <HeartIcon
                                               className="text-primary relative h-4 w-4"
                                               weight="fill"
                                           />
@@ -250,7 +250,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <Code className="text-foreground/60 relative h-4 w-4" />
+                                          <CodeIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">How We Build</span>
                                       </Link>
 
@@ -262,10 +262,10 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <GithubLogo className="text-foreground/60 relative h-4 w-4" />
+                                          <GithubLogoIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative flex items-center gap-1">
                                               Source Code
-                                              <ArrowSquareOut className="h-3 w-3 opacity-50" />
+                                              <ArrowSquareOutIcon className="h-3 w-3 opacity-50" />
                                           </span>
                                       </Link>
 
@@ -277,7 +277,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                                   onClick={() => setIsOpen(false)}
                                                   className="hover:text-foreground/80 flex items-center gap-1 transition-colors"
                                               >
-                                                  <Lock className="h-3 w-3" />
+                                                  <LockIcon className="h-3 w-3" />
                                                   Privacy
                                               </Link>
                                               <span className="text-foreground/20">
@@ -288,7 +288,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                                   onClick={() => setIsOpen(false)}
                                                   className="hover:text-foreground/80 flex items-center gap-1 transition-colors"
                                               >
-                                                  <FileText className="h-3 w-3" />
+                                                  <FileTextIcon className="h-3 w-3" />
                                                   Terms
                                               </Link>
                                               <span className="text-foreground/20">
@@ -299,7 +299,7 @@ export function OracleMenu({ className, showLabel = false }: OracleMenuProps) {
                                                   onClick={() => setIsOpen(false)}
                                                   className="hover:text-foreground/80 flex items-center gap-1 transition-colors"
                                               >
-                                                  <Shield className="h-3 w-3" />
+                                                  <ShieldIcon className="h-3 w-3" />
                                                   Security
                                               </Link>
                                           </div>

--- a/components/ui/oracle-whisper.tsx
+++ b/components/ui/oracle-whisper.tsx
@@ -24,7 +24,7 @@ const TIPS_DISABLED = true;
 
 import { useState, useEffect, useCallback } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { X, ArrowRight } from "@phosphor-icons/react";
+import { XIcon, ArrowRightIcon } from "@phosphor-icons/react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -311,7 +311,7 @@ export function OracleWhisper({ className }: OracleWhisperProps) {
                                         className="text-foreground/40 hover:bg-foreground/10 hover:text-foreground/60 flex h-5 w-5 shrink-0 items-center justify-center rounded-full transition-all"
                                         aria-label="Dismiss"
                                     >
-                                        <X className="h-3 w-3" />
+                                        <XIcon className="h-3 w-3" />
                                     </button>
                                 </div>
 
@@ -348,7 +348,7 @@ export function OracleWhisper({ className }: OracleWhisperProps) {
                                                         className="group/cta bg-primary/10 text-primary hover:bg-primary/20 inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-all"
                                                     >
                                                         {tip.cta.label}
-                                                        <ArrowRight className="h-3 w-3 transition-transform group-hover/cta:translate-x-0.5" />
+                                                        <ArrowRightIcon className="h-3 w-3 transition-transform group-hover/cta:translate-x-0.5" />
                                                     </Link>
                                                 )}
                                             {tip.cta.action === "settings" && (
@@ -358,7 +358,7 @@ export function OracleWhisper({ className }: OracleWhisperProps) {
                                                     className="group/cta bg-primary/10 text-primary hover:bg-primary/20 inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-all"
                                                 >
                                                     {tip.cta.label}
-                                                    <ArrowRight className="h-3 w-3 transition-transform group-hover/cta:translate-x-0.5" />
+                                                    <ArrowRightIcon className="h-3 w-3 transition-transform group-hover/cta:translate-x-0.5" />
                                                 </button>
                                             )}
                                         </>

--- a/components/ui/regenerate-button.tsx
+++ b/components/ui/regenerate-button.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import { ArrowClockwise } from "@phosphor-icons/react";
+import { ArrowClockwiseIcon } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
@@ -111,7 +111,7 @@ export function RegenerateButton({
                             opacity: { duration: 0.15 },
                         }}
                     >
-                        <ArrowClockwise className="h-3.5 w-3.5" />
+                        <ArrowClockwiseIcon className="h-3.5 w-3.5" />
                     </motion.div>
                 ) : (
                     <motion.div
@@ -121,7 +121,7 @@ export function RegenerateButton({
                         exit={{ opacity: 0 }}
                         transition={{ duration: 0.15 }}
                     >
-                        <ArrowClockwise className="h-3.5 w-3.5" />
+                        <ArrowClockwiseIcon className="h-3.5 w-3.5" />
                     </motion.div>
                 )}
             </AnimatePresence>

--- a/components/ui/regenerate-menu.tsx
+++ b/components/ui/regenerate-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
-import { ArrowClockwise, CaretDown, Check } from "@phosphor-icons/react";
+import { ArrowClockwiseIcon, CaretDownIcon, CheckIcon } from "@phosphor-icons/react";
 import { motion, AnimatePresence } from "framer-motion";
 import { cn } from "@/lib/utils";
 import { MODELS, type ModelId } from "@/lib/model-config";
@@ -159,7 +159,7 @@ export function RegenerateMenu({
                                 opacity: { duration: 0.15 },
                             }}
                         >
-                            <ArrowClockwise className="h-4 w-4" />
+                            <ArrowClockwiseIcon className="h-4 w-4" />
                         </motion.div>
                     ) : (
                         <motion.div
@@ -169,7 +169,7 @@ export function RegenerateMenu({
                             exit={{ opacity: 0 }}
                             transition={{ duration: 0.15 }}
                         >
-                            <ArrowClockwise className="h-4 w-4" />
+                            <ArrowClockwiseIcon className="h-4 w-4" />
                         </motion.div>
                     )}
                 </AnimatePresence>
@@ -192,7 +192,7 @@ export function RegenerateMenu({
                                 : "text-foreground/60 hover:text-foreground/90"
                         )}
                     >
-                        <CaretDown
+                        <CaretDownIcon
                             className={cn(
                                 "h-4 w-4 transition-transform",
                                 isOpen && "rotate-180"
@@ -239,7 +239,7 @@ export function RegenerateMenu({
                                                     {model.displayName}
                                                 </span>
                                                 {isActive && (
-                                                    <Check className="text-primary h-3.5 w-3.5" />
+                                                    <CheckIcon className="text-primary h-3.5 w-3.5" />
                                                 )}
                                             </button>
                                         );

--- a/components/ui/stateful-button.tsx
+++ b/components/ui/stateful-button.tsx
@@ -3,11 +3,16 @@
 import * as React from "react";
 import { useState, useEffect, useCallback, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { CircleNotch, Check, WarningCircle, FloppyDisk } from "@phosphor-icons/react";
+import {
+    CircleNotchIcon,
+    CheckIcon,
+    WarningCircleIcon,
+    FloppyDiskIcon,
+} from "@phosphor-icons/react";
 import type { Icon as PhosphorIcon } from "@phosphor-icons/react";
 
-// Re-export FloppyDisk for convenience when using StatefulButton as a save button
-export { FloppyDisk };
+// Re-export FloppyDiskIcon for convenience when using StatefulButton as a save button
+export { FloppyDiskIcon };
 import { Button, buttonVariants, type ButtonProps } from "./button";
 import { cn } from "@/lib/utils";
 import { transitions } from "@/lib/motion/presets";
@@ -281,7 +286,7 @@ export const StatefulButton = React.forwardRef<HTMLButtonElement, StatefulButton
                                 transition={transitions.quick}
                                 className="inline-flex"
                             >
-                                <CircleNotch
+                                <CircleNotchIcon
                                     className={cn(
                                         iconSize,
                                         !prefersReducedMotion && "animate-spin"
@@ -300,7 +305,7 @@ export const StatefulButton = React.forwardRef<HTMLButtonElement, StatefulButton
                                 transition={transitions.quick}
                                 className="inline-flex text-green-600"
                             >
-                                <Check className={iconSize} aria-hidden="true" />
+                                <CheckIcon className={iconSize} aria-hidden="true" />
                             </motion.span>
                         )}
                         {showError && (
@@ -313,7 +318,7 @@ export const StatefulButton = React.forwardRef<HTMLButtonElement, StatefulButton
                                 transition={transitions.quick}
                                 className="inline-flex text-red-600"
                             >
-                                <WarningCircle
+                                <WarningCircleIcon
                                     className={iconSize}
                                     aria-hidden="true"
                                 />

--- a/components/ui/theme-switcher.tsx
+++ b/components/ui/theme-switcher.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useSyncExternalStore } from "react";
-import { Moon, Sun } from "@phosphor-icons/react";
+import { MoonIcon, SunIcon } from "@phosphor-icons/react";
 import { useTheme } from "next-themes";
 
 import { cn } from "@/lib/utils";
@@ -50,13 +50,13 @@ export function ThemeSwitcher({
                 className="relative"
                 aria-label="Toggle theme"
             >
-                <Sun className="text-foreground/70 size-4" />
+                <SunIcon className="text-foreground/70 size-4" />
             </Button>
         );
     }
 
     const isDark = resolvedTheme === "dark";
-    const Icon = isDark ? Moon : Sun;
+    const Icon = isDark ? MoonIcon : SunIcon;
 
     return (
         <Button

--- a/components/ui/theme-variant-selector.tsx
+++ b/components/ui/theme-variant-selector.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Check, Palette } from "@phosphor-icons/react";
+import { CheckIcon, PaletteIcon } from "@phosphor-icons/react";
 import {
     useThemeVariant,
     getCurrentHoliday,
@@ -81,7 +81,7 @@ export function ThemeVariantSelector() {
                     "hover:bg-foreground/5 focus:ring-primary/40 focus:ring-2 focus:outline-none"
                 )}
             >
-                <Palette className="text-foreground/60 h-4 w-4" />
+                <PaletteIcon className="text-foreground/60 h-4 w-4" />
                 <span className="text-foreground/90">{currentTheme?.label}</span>
             </Popover.Trigger>
 
@@ -105,7 +105,7 @@ export function ThemeVariantSelector() {
                             >
                                 <div className="flex h-5 w-5 shrink-0 items-center justify-center">
                                     {themeVariant === theme.value && (
-                                        <Check className="h-4 w-4" />
+                                        <CheckIcon className="h-4 w-4" />
                                     )}
                                 </div>
                                 <div className="flex-1 space-y-0.5">

--- a/components/ui/toggletip.tsx
+++ b/components/ui/toggletip.tsx
@@ -20,7 +20,7 @@
  */
 
 import * as React from "react";
-import { Question } from "@phosphor-icons/react";
+import { QuestionIcon } from "@phosphor-icons/react";
 
 import { Popover, PopoverTrigger, PopoverContent } from "./popover";
 import { cn } from "@/lib/utils";
@@ -73,7 +73,7 @@ export function Toggletip({
                     )}
                     aria-label="More information"
                 >
-                    <Question size={iconSize} weight="bold" />
+                    <QuestionIcon size={iconSize} weight="bold" />
                 </button>
             </PopoverTrigger>
             <PopoverContent
@@ -132,7 +132,7 @@ export function InlineToggletip({
                     )}
                     aria-label="More information"
                 >
-                    <Question size={12} weight="bold" />
+                    <QuestionIcon size={12} weight="bold" />
                 </Trigger>
             </PopoverTrigger>
             <PopoverContent

--- a/components/ui/user-auth-button.tsx
+++ b/components/ui/user-auth-button.tsx
@@ -2,16 +2,16 @@
 
 import { useAuth, useUser, useClerk } from "@clerk/nextjs";
 import {
-    User,
-    SignOut,
-    Moon,
-    Sun,
-    UserCircle,
-    Monitor,
-    Plug,
-    Plus,
-    BookOpen,
-    ChatTeardrop,
+    UserIcon,
+    SignOutIcon,
+    MoonIcon,
+    SunIcon,
+    UserCircleIcon,
+    MonitorIcon,
+    PlugIcon,
+    PlusIcon,
+    BookOpenIcon,
+    ChatTeardropIcon,
 } from "@phosphor-icons/react";
 
 import { AnimatePresence, motion } from "framer-motion";
@@ -123,9 +123,9 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
     const email = user.primaryEmailAddress?.emailAddress;
 
     const themeOptions = [
-        { value: "light", label: "Light", icon: Sun },
-        { value: "dark", label: "Dark", icon: Moon },
-        { value: "system", label: "System", icon: Monitor },
+        { value: "light", label: "Light", icon: SunIcon },
+        { value: "dark", label: "Dark", icon: MoonIcon },
+        { value: "system", label: "System", icon: MonitorIcon },
     ] as const;
 
     // Theme variants with primary color for swatch preview
@@ -247,7 +247,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                           className="group text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm font-medium transition-all"
                                       >
                                           <div className="bg-primary/10 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <Plus className="text-primary relative h-4 w-4" />
+                                          <PlusIcon className="text-primary relative h-4 w-4" />
                                           <span className="relative">
                                               New Connection
                                           </span>
@@ -262,7 +262,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <BookOpen className="text-foreground/60 relative h-4 w-4" />
+                                          <BookOpenIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">
                                               Knowledge Base
                                           </span>
@@ -274,7 +274,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <Plug className="text-foreground/60 relative h-4 w-4" />
+                                          <PlugIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">Integrations</span>
                                       </Link>
 
@@ -284,7 +284,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <ChatTeardrop className="text-foreground/60 relative h-4 w-4" />
+                                          <ChatTeardropIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">
                                               Communication
                                           </span>
@@ -301,7 +301,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <User className="text-foreground/60 relative h-4 w-4" />
+                                          <UserIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">Account</span>
                                       </button>
 
@@ -415,7 +415,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                                           className="group text-foreground/80 hover:text-foreground relative flex w-full items-center gap-3 px-4 py-2.5 text-sm transition-all"
                                       >
                                           <div className="bg-primary/5 pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-200 group-hover:opacity-100" />
-                                          <SignOut className="text-foreground/60 relative h-4 w-4" />
+                                          <SignOutIcon className="text-foreground/60 relative h-4 w-4" />
                                           <span className="relative">Exit</span>
                                       </Link>
                                   </div>
@@ -439,7 +439,7 @@ export function UserAuthButton({ className }: UserAuthButtonProps) {
                 data-tooltip-id="tip"
                 data-tooltip-content="Settings & integrations"
             >
-                <UserCircle
+                <UserCircleIcon
                     className="text-foreground/50 group-hover:text-foreground/80 h-5 w-5 transition-colors sm:h-6 sm:w-6 md:h-7 md:w-7"
                     weight="duotone"
                 />

--- a/components/voice/voice-input-button.tsx
+++ b/components/voice/voice-input-button.tsx
@@ -17,7 +17,11 @@ import {
     useState,
 } from "react";
 import { AnimatePresence, motion } from "framer-motion";
-import { Microphone, MicrophoneSlash, CircleNotch } from "@phosphor-icons/react";
+import {
+    MicrophoneIcon,
+    MicrophoneSlashIcon,
+    CircleNotchIcon,
+} from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { useVoiceInput } from "@/lib/hooks/use-voice-input";
@@ -206,7 +210,7 @@ export const VoiceInputButton = forwardRef<VoiceInputButtonRef, VoiceInputButton
                             exit={{ opacity: 0, scale: 0.8 }}
                             transition={{ duration: 0.15 }}
                         >
-                            <CircleNotch className="h-5 w-5 animate-spin sm:h-6 sm:w-6" />
+                            <CircleNotchIcon className="h-5 w-5 animate-spin sm:h-6 sm:w-6" />
                         </motion.div>
                     ) : isListening ? (
                         <motion.div
@@ -217,7 +221,7 @@ export const VoiceInputButton = forwardRef<VoiceInputButtonRef, VoiceInputButton
                             transition={{ duration: 0.15 }}
                             className="relative"
                         >
-                            <Microphone className="text-primary-foreground h-5 w-5 sm:h-6 sm:w-6" />
+                            <MicrophoneIcon className="text-primary-foreground h-5 w-5 sm:h-6 sm:w-6" />
                             {/* Pulsing ring animation */}
                             <motion.div
                                 className="border-primary-foreground/60 absolute inset-0 rounded-full border-2"
@@ -238,7 +242,7 @@ export const VoiceInputButton = forwardRef<VoiceInputButtonRef, VoiceInputButton
                             exit={{ opacity: 0, scale: 0.8 }}
                             transition={{ duration: 0.15 }}
                         >
-                            <MicrophoneSlash className="h-5 w-5 sm:h-6 sm:w-6" />
+                            <MicrophoneSlashIcon className="h-5 w-5 sm:h-6 sm:w-6" />
                         </motion.div>
                     ) : (
                         <motion.div
@@ -248,7 +252,7 @@ export const VoiceInputButton = forwardRef<VoiceInputButtonRef, VoiceInputButton
                             exit={{ opacity: 0, scale: 0.8 }}
                             transition={{ duration: 0.15 }}
                         >
-                            <Microphone
+                            <MicrophoneIcon
                                 className={cn(
                                     "h-5 w-5 transition-colors sm:h-6 sm:w-6",
                                     variant === "primary"

--- a/knowledge/components/contextual-help.md
+++ b/knowledge/components/contextual-help.md
@@ -198,14 +198,15 @@ reveal). If it's just a label, ensure the icon is obvious or add text.
 
 ### ✅ Help Icon Design
 
-**Decision**: Use `Question` from Phosphor Icons, 12-14px, 30-40% opacity until hover.
+**Decision**: Use `QuestionIcon` from Phosphor Icons, 12-14px, 30-40% opacity until
+hover.
 
 **Rationale**: Help icons should be present but not prominent. They're for users who
 need them, invisible to those who don't. The subtle treatment keeps the UI clean while
 making help discoverable.
 
 ```tsx
-<Question
+<QuestionIcon
   size={12}
   weight="bold"
   className="opacity-30 transition-opacity hover:opacity-70"

--- a/knowledge/components/icon-system.md
+++ b/knowledge/components/icon-system.md
@@ -1,6 +1,7 @@
 # Icon System
 
-**Current**: Lucide React (v0.562.0) - 117 imports across 115 files
+**Current**: Phosphor Icons (v2.1.10+) - All icons use the `Icon` suffix naming
+convention (e.g., `ArrowRightIcon`, `CheckIcon`, `SparkleIcon`)
 
 ## Why This Matters
 
@@ -50,7 +51,7 @@ consistent styling trivial.
 </IconContext.Provider>
 
 // Duotone example - depth without complexity
-<Cube color="teal" weight="duotone" />
+<CubeIcon color="teal" weight="duotone" />
 ```
 
 ### Other Options Considered
@@ -186,7 +187,8 @@ Systematic find-replace:
 
 ```
 // Pattern: import { IconName } from "lucide-react"
-// Replace: import { IconName } from "@phosphor-icons/react"
+// Replace: import { IconNameIcon } from "@phosphor-icons/react"
+// Note: Phosphor Icons v2.1.8+ requires the "Icon" suffix for all icon components
 ```
 
 Most icons have direct equivalents. Handle edge cases manually.

--- a/lib/code-mode/file-utils.ts
+++ b/lib/code-mode/file-utils.ts
@@ -5,13 +5,13 @@
  */
 
 import {
-    File,
-    FileCode,
-    FileJs,
-    FileText,
-    FileImage,
-    Folder,
-    FolderOpen,
+    FileIcon,
+    FileCodeIcon,
+    FileJsIcon,
+    FileTextIcon,
+    ImageIcon as FileImageIcon,
+    FolderIcon,
+    FolderOpenIcon,
     type Icon,
 } from "@phosphor-icons/react";
 
@@ -108,17 +108,17 @@ const IMAGE_EXTENSIONS = new Set([
  */
 export function getFileIcon(entry: FileEntry, isOpen?: boolean): Icon {
     if (entry.type === "directory") {
-        return isOpen ? FolderOpen : Folder;
+        return isOpen ? FolderOpenIcon : FolderIcon;
     }
 
     const ext = entry.extension?.toLowerCase() ?? "";
 
-    if (CODE_EXTENSIONS.has(ext)) return FileCode;
-    if (CONFIG_EXTENSIONS.has(ext)) return FileJs;
-    if (TEXT_EXTENSIONS.has(ext)) return FileText;
-    if (IMAGE_EXTENSIONS.has(ext)) return FileImage;
+    if (CODE_EXTENSIONS.has(ext)) return FileCodeIcon;
+    if (CONFIG_EXTENSIONS.has(ext)) return FileJsIcon;
+    if (TEXT_EXTENSIONS.has(ext)) return FileTextIcon;
+    if (IMAGE_EXTENSIONS.has(ext)) return FileImageIcon;
 
-    return File;
+    return FileIcon;
 }
 
 /**

--- a/lib/sparks/generator.ts
+++ b/lib/sparks/generator.ts
@@ -1,16 +1,16 @@
 import {
-    Calendar,
-    Envelope,
-    Chat,
-    Star,
-    Clock,
-    Sparkle,
-    MagnifyingGlass,
-    Brain,
-    Plug,
-    FileText,
-    TrendUp,
-    Microphone,
+    CalendarIcon,
+    EnvelopeIcon,
+    ChatIcon,
+    StarIcon,
+    ClockIcon,
+    SparkleIcon,
+    MagnifyingGlassIcon,
+    BrainIcon,
+    PlugIcon,
+    FileTextIcon,
+    TrendUpIcon,
+    MicrophoneIcon,
     type Icon,
 } from "@phosphor-icons/react";
 
@@ -135,22 +135,22 @@ const DISCOVERY_SPARKS: Array<{ label: string; prompt: string; icon: Icon }> = [
     {
         label: "Help me brainstorm ideas",
         prompt: "I want to brainstorm some ideas. Let's start with...",
-        icon: Brain,
+        icon: BrainIcon,
     },
     {
         label: "Search the web for...",
         prompt: "Search the web for ",
-        icon: MagnifyingGlass,
+        icon: MagnifyingGlassIcon,
     },
     {
         label: "Draft something for me",
         prompt: "Help me draft ",
-        icon: FileText,
+        icon: FileTextIcon,
     },
     {
         label: "Analyze this data",
         prompt: "I have some data I'd like to analyze: ",
-        icon: TrendUp,
+        icon: TrendUpIcon,
     },
 ];
 
@@ -159,17 +159,17 @@ const DISCOVERY_SPARKS: Array<{ label: string; prompt: string; icon: Icon }> = [
  */
 function getIconForService(serviceId: string): Icon {
     const iconMap: Record<string, Icon> = {
-        gmail: Envelope,
-        "google-calendar-contacts": Calendar,
-        slack: Chat,
-        notion: FileText,
-        clickup: Clock,
-        fireflies: Microphone,
-        limitless: Microphone,
-        coinmarketcap: TrendUp,
-        twitter: Chat,
+        gmail: EnvelopeIcon,
+        "google-calendar-contacts": CalendarIcon,
+        slack: ChatIcon,
+        notion: FileTextIcon,
+        clickup: ClockIcon,
+        fireflies: MicrophoneIcon,
+        limitless: MicrophoneIcon,
+        coinmarketcap: TrendUpIcon,
+        twitter: ChatIcon,
     };
-    return iconMap[serviceId] ?? Sparkle;
+    return iconMap[serviceId] ?? SparkleIcon;
 }
 
 /**
@@ -225,7 +225,7 @@ function generateOnboardingSpark(connectedCount: number): Spark {
     return {
         id: "onboarding-integrations",
         label,
-        icon: Plug,
+        icon: PlugIcon,
         category: "setup",
         action: {
             type: "navigate",
@@ -278,7 +278,7 @@ function generateRecentThreadSpark(thread: RecentThread): Spark {
     return {
         id: `recent-${thread.id}`,
         label: `Continue: ${displayTitle}`,
-        icon: Clock,
+        icon: ClockIcon,
         category: "continue",
         action: {
             type: "deeplink",
@@ -301,7 +301,7 @@ function generateStarredThreadSparks(
         return {
             id: `starred-${thread.id}`,
             label: displayTitle,
-            icon: Star,
+            icon: StarIcon,
             category: "continue",
             action: {
                 type: "deeplink",

--- a/lib/tools/tool-config.ts
+++ b/lib/tools/tool-config.ts
@@ -1,26 +1,26 @@
 import {
-    Table,
-    MagnifyingGlass,
-    Globe,
-    Brain,
-    CloudSun,
-    BookOpen,
-    Sparkle,
-    Calculator,
-    FileText,
-    PencilSimple,
-    Pencil,
-    Terminal,
-    FolderOpen,
-    FileMagnifyingGlass,
-    Robot,
-    ListChecks,
-    Code,
-    Notebook,
-    ChatCircleDots,
-    Link,
-    Question,
-    Heart,
+    TableIcon,
+    MagnifyingGlassIcon,
+    GlobeIcon,
+    BrainIcon,
+    CloudSunIcon,
+    BookOpenIcon,
+    SparkleIcon,
+    CalculatorIcon,
+    FileTextIcon,
+    PencilSimpleIcon,
+    PencilIcon,
+    TerminalIcon,
+    FolderOpenIcon,
+    FileMagnifyingGlassIcon,
+    RobotIcon,
+    ListChecksIcon,
+    CodeIcon,
+    NotebookIcon,
+    ChatCircleDotsIcon,
+    LinkIcon,
+    QuestionIcon,
+    HeartIcon,
     type Icon,
 } from "@phosphor-icons/react";
 import { logger } from "@/lib/client-logger";
@@ -71,7 +71,7 @@ export interface ToolConfig {
 export const TOOL_CONFIG: Record<string, ToolConfig> = {
     compareOptions: {
         displayName: "Comparison",
-        icon: Table,
+        icon: TableIcon,
         getDescription: (args) => {
             const title = args.title as string | undefined;
             return title ? truncate(title, 40) : undefined;
@@ -89,7 +89,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     webSearch: {
         displayName: "Web Search",
-        icon: MagnifyingGlass,
+        icon: MagnifyingGlassIcon,
         getDescription: (args) => {
             const query = args.query as string | undefined;
             return query ? truncate(query, 50) : undefined;
@@ -107,7 +107,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     fetchPage: {
         displayName: "Fetch Page",
-        icon: Globe,
+        icon: GlobeIcon,
         getDescription: (args) => {
             const url = args.url as string | undefined;
             if (!url) return undefined;
@@ -130,7 +130,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     deepResearch: {
         displayName: "Deep Research",
-        icon: Brain,
+        icon: BrainIcon,
         getDescription: (args) => {
             const topic = args.topic as string | undefined;
             return topic ? truncate(topic, 50) : undefined;
@@ -148,7 +148,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     getWeather: {
         displayName: "Weather",
-        icon: CloudSun,
+        icon: CloudSunIcon,
         getDescription: (args) => {
             const location = args.location as string | undefined;
             return location ? truncate(location, 30) : undefined;
@@ -166,7 +166,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     searchKnowledge: {
         displayName: "Knowledge Base",
-        icon: BookOpen,
+        icon: BookOpenIcon,
         getDescription: (args) => {
             const query = args.query as string | undefined;
             return query ? truncate(query, 50) : undefined;
@@ -185,7 +185,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     // Discovery tools - progressive context building
     updateDiscovery: {
         displayName: "Discovery",
-        icon: Sparkle,
+        icon: SparkleIcon,
         getDescription: (args) => {
             const key = args.key as string | undefined;
             return key ? truncate(key, 30) : undefined;
@@ -203,7 +203,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     completeDiscovery: {
         displayName: "Discovery",
-        icon: Sparkle,
+        icon: SparkleIcon,
         messages: {
             pending: "Getting ready...",
             running: "Completing discovery...",
@@ -216,7 +216,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     skipDiscovery: {
         displayName: "Discovery",
-        icon: Sparkle,
+        icon: SparkleIcon,
         messages: {
             pending: "Getting ready...",
             running: "Skipping discovery...",
@@ -245,7 +245,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     // Service integrations (alphabetical order)
     calculate: {
         displayName: "Calculator",
-        icon: Calculator,
+        icon: CalculatorIcon,
         messages: {
             pending: "Getting ready...",
             running: "Crunching numbers...",
@@ -479,7 +479,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Read: {
         displayName: "Read File",
-        icon: FileText,
+        icon: FileTextIcon,
         getDescription: (args) => {
             const filePath = args.file_path as string | undefined;
             if (!filePath) return undefined;
@@ -500,7 +500,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Write: {
         displayName: "Write File",
-        icon: PencilSimple,
+        icon: PencilSimpleIcon,
         getDescription: (args) => {
             const filePath = args.file_path as string | undefined;
             if (!filePath) return undefined;
@@ -521,7 +521,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Edit: {
         displayName: "Edit File",
-        icon: Pencil,
+        icon: PencilIcon,
         getDescription: (args) => {
             const filePath = args.file_path as string | undefined;
             if (!filePath) return undefined;
@@ -542,7 +542,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Bash: {
         displayName: "Run Command",
-        icon: Terminal,
+        icon: TerminalIcon,
         getDescription: (args) => {
             const command = args.command as string | undefined;
             if (!command) return undefined;
@@ -566,7 +566,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Glob: {
         displayName: "Find Files",
-        icon: FolderOpen,
+        icon: FolderOpenIcon,
         getDescription: (args) => {
             const pattern = args.pattern as string | undefined;
             return pattern ? truncate(pattern, 40) : undefined;
@@ -585,7 +585,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Grep: {
         displayName: "Search Code",
-        icon: FileMagnifyingGlass,
+        icon: FileMagnifyingGlassIcon,
         getDescription: (args) => {
             const pattern = args.pattern as string | undefined;
             return pattern ? truncate(`"${pattern}"`, 40) : undefined;
@@ -604,7 +604,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     Task: {
         displayName: "Sub-Agent",
-        icon: Robot,
+        icon: RobotIcon,
         getDescription: (args) => {
             const agentType = args.subagent_type as string | undefined;
             const description = args.description as string | undefined;
@@ -623,7 +623,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     TodoWrite: {
         displayName: "Task List",
-        icon: ListChecks,
+        icon: ListChecksIcon,
         messages: {
             pending: "Getting ready...",
             running: "Updating tasks...",
@@ -638,7 +638,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     LSP: {
         displayName: "Code Intelligence",
-        icon: Code,
+        icon: CodeIcon,
         getDescription: (args) => {
             const operation = args.operation as string | undefined;
             return operation;
@@ -657,7 +657,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     NotebookEdit: {
         displayName: "Edit Notebook",
-        icon: Notebook,
+        icon: NotebookIcon,
         messages: {
             pending: "Getting ready...",
             running: "Editing notebook...",
@@ -672,7 +672,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     WebFetch: {
         displayName: "Fetch Page",
-        icon: Globe,
+        icon: GlobeIcon,
         getDescription: (args) => {
             const url = args.url as string | undefined;
             if (!url) return undefined;
@@ -696,7 +696,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
 
     WebSearch: {
         displayName: "Web Search",
-        icon: MagnifyingGlass,
+        icon: MagnifyingGlassIcon,
         getDescription: (args) => {
             const query = args.query as string | undefined;
             return query ? truncate(query, 50) : undefined;
@@ -715,7 +715,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     // Post-response enhancement tools
     suggestQuestions: {
         displayName: "Follow-ups",
-        icon: ChatCircleDots,
+        icon: ChatCircleDotsIcon,
         getDescription: (args) => {
             const suggestions = args.suggestions as
                 | Array<{ prompt: string }>
@@ -735,7 +735,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     showReferences: {
         displayName: "Sources",
-        icon: Link,
+        icon: LinkIcon,
         getDescription: (args) => {
             const refs = args.references as Array<{ title: string }> | undefined;
             if (!refs?.length) return undefined;
@@ -753,7 +753,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     askUserInput: {
         displayName: "Question",
-        icon: Question,
+        icon: QuestionIcon,
         getDescription: (args) => {
             const question = args.question as string | undefined;
             return question ? truncate(question, 40) : undefined;
@@ -767,7 +767,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
     },
     acknowledge: {
         displayName: "Appreciation",
-        icon: Heart,
+        icon: HeartIcon,
         messages: {
             pending: "Getting ready...",
             running: "Thinking...",
@@ -785,7 +785,7 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
  */
 export const DEFAULT_TOOL_CONFIG: ToolConfig = {
     displayName: "Tool",
-    icon: MagnifyingGlass,
+    icon: MagnifyingGlassIcon,
     messages: {
         pending: "Getting ready...",
         running: "Working through this...",


### PR DESCRIPTION
## Summary
Updated all deprecated Phosphor Icons imports across the codebase to use the `Icon` suffix naming convention required by Phosphor Icons v2.1.8+.

## Changes
- Updated 100+ component files, library files, and app pages
- All icon imports now use Icon suffix (e.g., `ArrowRightIcon`, `CheckIcon`, `SparkleIcon`)
- Updated documentation examples in `icon-system.md` and `contextual-help.md` to reflect correct naming pattern
- Fixed all linting errors related to deprecated icon names

## Files Updated
- Component files: `components/ui/*`, `components/connection/*`, `components/tools/*`, etc.
- App pages: `app/ai-team/*`, `app/code/*`, `app/integrations/*`, etc.
- Library files: `lib/tools/tool-config.ts`, `lib/sparks/generator.ts`, `lib/code-mode/file-utils.ts`
- Documentation: `knowledge/components/icon-system.md`, `knowledge/components/contextual-help.md`

## Testing
- All pre-commit checks passed
- All tests passed (2129 tests)
- Type checking passed
- No linting errors
- All icons now comply with Phosphor Icons v2.1.8+ naming requirements