### PR TITLE
✨ Add smsUser tool for proactive SMS messaging

### DIFF
--- a/lib/ai-team/agents/sms-user-tool.ts
+++ b/lib/ai-team/agents/sms-user-tool.ts
@@ -1,0 +1,240 @@
+/**
+ * SMS User Tool for DCOS
+ *
+ * Enables Carmenta to proactively text users via SMS.
+ * This is system-level messaging - Carmenta reaching out, not just responding.
+ *
+ * Uses QuoNotificationService under the hood with dedicated API key.
+ * Requires user to have a verified, opted-in phone number.
+ */
+
+import { tool } from "ai";
+import * as Sentry from "@sentry/nextjs";
+import { z } from "zod";
+
+import { logger } from "@/lib/logger";
+import { sendNotification } from "@/lib/sms/quo-notification-service";
+import {
+    type SubagentResult,
+    type SubagentDescription,
+    type SubagentContext,
+    successResult,
+    errorResult,
+} from "@/lib/ai-team/dcos/types";
+import { safeInvoke } from "@/lib/ai-team/dcos/utils";
+
+const TOOL_ID = "smsUser";
+
+/**
+ * Describe tool operations for progressive disclosure
+ */
+function describeOperations(): SubagentDescription {
+    return {
+        id: TOOL_ID,
+        name: "SMS User",
+        summary:
+            "Text them via SMS. Use when there's something important to share proactively - agent results, alerts, reminders.",
+        operations: [
+            {
+                name: "send",
+                description:
+                    "Send an SMS to their verified phone number. Keep messages brief (1-2 segments, ~160-320 chars). Requires a verified, opted-in phone number.",
+                params: [
+                    {
+                        name: "message",
+                        type: "string",
+                        description:
+                            "The SMS content. Keep it conversational and brief - SMS isn't email.",
+                        required: true,
+                    },
+                    {
+                        name: "reason",
+                        type: "string",
+                        description:
+                            "Why you're texting: briefing, alert, reminder, or agent. Helps with routing.",
+                        required: false,
+                    },
+                ],
+            },
+        ],
+    };
+}
+
+/**
+ * Result data for send action
+ */
+interface SendData {
+    sent: boolean;
+    messageId?: number;
+    quoMessageId?: string;
+}
+
+/**
+ * Execute send action
+ */
+async function executeSend(
+    params: { message: string; reason?: string },
+    context: SubagentContext
+): Promise<SubagentResult<SendData>> {
+    const { message, reason } = params;
+
+    // Map reason to source type
+    const sourceMap: Record<
+        string,
+        "briefing" | "alert" | "reminder" | "scheduled_agent"
+    > = {
+        briefing: "briefing",
+        alert: "alert",
+        reminder: "reminder",
+        agent: "scheduled_agent",
+        scheduled: "scheduled_agent",
+    };
+
+    const source = sourceMap[reason?.toLowerCase() ?? ""] ?? "alert";
+
+    try {
+        const result = await sendNotification({
+            userEmail: context.userEmail,
+            content: message,
+            source,
+        });
+
+        if (!result.success) {
+            logger.warn(
+                {
+                    userEmail: context.userEmail,
+                    error: result.error,
+                },
+                "📱 SMS failed - user may not have verified phone"
+            );
+
+            return errorResult(
+                "VALIDATION",
+                result.error ??
+                    "No verified phone number on file. They'll need to add one in settings."
+            );
+        }
+
+        logger.info(
+            {
+                userEmail: context.userEmail,
+                messageId: result.messageId,
+                quoMessageId: result.quoMessageId,
+                source,
+            },
+            "📱 SMS sent"
+        );
+
+        return successResult<SendData>({
+            sent: true,
+            messageId: result.messageId,
+            quoMessageId: result.quoMessageId,
+        });
+    } catch (error) {
+        logger.error(
+            { error, userEmail: context.userEmail },
+            "📱 SMS failed unexpectedly"
+        );
+
+        Sentry.captureException(error, {
+            tags: { component: "smsUser", action: "send" },
+            extra: { userEmail: context.userEmail, messageLength: message.length },
+        });
+
+        return errorResult(
+            "PERMANENT",
+            error instanceof Error
+                ? `SMS couldn't go through: ${error.message}`
+                : "SMS couldn't go through. The robots have been notified. 🤖"
+        );
+    }
+}
+
+/**
+ * Tool input schema
+ */
+const smsUserSchema = z.object({
+    action: z
+        .enum(["describe", "send"])
+        .describe("Operation to perform. Use 'describe' to see full documentation."),
+    message: z
+        .string()
+        .optional()
+        .describe("SMS content. Keep brief - aim for 1-2 segments (160-320 chars)."),
+    reason: z
+        .string()
+        .optional()
+        .describe("Why you're texting: briefing, alert, reminder, or agent."),
+});
+
+type SmsUserAction = z.infer<typeof smsUserSchema>;
+
+/**
+ * Validate required fields
+ */
+function validateParams(
+    params: SmsUserAction
+): { valid: true } | { valid: false; error: string } {
+    if (params.action === "describe") {
+        return { valid: true };
+    }
+
+    if (params.action === "send") {
+        if (!params.message) {
+            return { valid: false, error: "message is required for send" };
+        }
+        if (params.message.length > 1600) {
+            return {
+                valid: false,
+                error: "message too long - keep under 1600 chars (10 segments max)",
+            };
+        }
+        return { valid: true };
+    }
+
+    return { valid: false, error: `Unknown action: ${params.action}` };
+}
+
+/**
+ * Create the smsUser tool for DCOS
+ *
+ * Enables Carmenta to text users proactively via SMS.
+ * Uses progressive disclosure - call with action='describe' for full docs.
+ */
+export function createSmsUserTool(context: SubagentContext) {
+    return tool({
+        description:
+            "Text them via SMS. Use when there's something important to share proactively. Requires a verified phone number.",
+        inputSchema: smsUserSchema,
+        execute: async (params: SmsUserAction) => {
+            if (params.action === "describe") {
+                return describeOperations();
+            }
+
+            const validation = validateParams(params);
+            if (!validation.valid) {
+                return errorResult("VALIDATION", validation.error);
+            }
+
+            const result = await safeInvoke(
+                TOOL_ID,
+                params.action,
+                async (ctx) => {
+                    if (params.action === "send") {
+                        return executeSend(
+                            { message: params.message!, reason: params.reason },
+                            ctx
+                        );
+                    }
+                    return errorResult(
+                        "VALIDATION",
+                        `Unknown action: ${params.action}`
+                    );
+                },
+                context
+            );
+
+            return result;
+        },
+    });
+}

--- a/lib/ai-team/dcos/agent.ts
+++ b/lib/ai-team/dcos/agent.ts
@@ -28,6 +28,7 @@ import { type SubagentContext, type DCOSInput } from "./types";
 import { createLibrarianTool } from "../agents/librarian-tool";
 import { createMcpConfigTool } from "../agents/mcp-config-tool";
 import { createDcosTool } from "../agents/dcos-tool";
+import { createSmsUserTool } from "../agents/sms-user-tool";
 
 /**
  * Default model for DCOS
@@ -101,6 +102,8 @@ function getSubagentStatusMessage(toolName: string, action?: string): string {
             return "Researching...";
         case "searchKnowledge":
             return "Searching knowledge...";
+        case "smsUser":
+            return "Texting you...";
         default:
             // Integration tools
             return `Using ${toolName}...`;
@@ -138,6 +141,7 @@ export async function executeDCOS(input: DCOSExecutionInput) {
     const librarianTool = createLibrarianTool(subagentContext);
     const mcpConfigTool = createMcpConfigTool(subagentContext);
     const dcosTool = createDcosTool(subagentContext);
+    const smsUserTool = createSmsUserTool(subagentContext);
 
     // Load integration tools for connected services
     const integrationTools = await getIntegrationTools(userEmail);
@@ -151,6 +155,7 @@ export async function executeDCOS(input: DCOSExecutionInput) {
         librarian: librarianTool,
         mcpConfig: mcpConfigTool,
         searchKnowledge: searchKnowledgeTool,
+        smsUser: smsUserTool,
         ...integrationTools,
     };
 

--- a/lib/tools/tool-config.ts
+++ b/lib/tools/tool-config.ts
@@ -550,6 +550,25 @@ export const TOOL_CONFIG: Record<string, ToolConfig> = {
             fast: ["Quick!", "Sent"],
         },
     },
+    smsUser: {
+        displayName: "SMS",
+        icon: ChatCircleDotsIcon,
+        getDescription: (args) => {
+            const action = args.action as string | undefined;
+            if (action === "send") return "texting you";
+            return action;
+        },
+        messages: {
+            pending: "Getting ready...",
+            running: "Texting you...",
+            completed: "Sent",
+            error: "That didn't go through. Make sure you have a verified phone in settings.",
+        },
+        delightMessages: {
+            completed: ["On its way", "Headed your way", "Check your phone"],
+            fast: ["Quick!", "Already there"],
+        },
+    },
     slack: {
         displayName: "Slack",
         icon: "/logos/slack.svg",


### PR DESCRIPTION
## Summary

- Adds `smsUser` tool enabling Carmenta to proactively text users via SMS
- Uses the existing internal Quo integration (`QuoNotificationService`)
- Requires verified, opted-in phone number for delivery
- Follows DCOS tool conventions (progressive disclosure, structured results)

## What This Enables

Carmenta can now reach out to users via SMS when there's something important to share:
- Agent results ("Your report is ready")
- Alerts ("Unusual activity detected")
- Reminders ("Meeting in 30 minutes")
- Briefings ("Here's your morning summary")

This is Carmenta *initiating* contact, not just responding.

## Changes

- `lib/ai-team/agents/sms-user-tool.ts` - New tool wrapping QuoNotificationService
- `lib/ai-team/dcos/agent.ts` - Register tool with DCOS
- `lib/tools/tool-config.ts` - UI display config with Carmenta voice

## Testing

The underlying `QuoNotificationService` has existing tests. The tool is a thin wrapper
following the established pattern of other DCOS tools (librarian, mcpConfig).

## Notes

- Tool-level rate limiting deferred for now (underlying service already has 10 req/s limit)
- Users must have verified, opted-in phone number (enforced by service layer)
- All SMS sends are logged to `sms_outbound_messages` for audit trail

Generated with Carmenta