### PR TITLE
🐛 Rename moveDocument params to prevent LLM confusion

### DIFF
--- a/__tests__/unit/lib/ai-team/librarian/tools.test.ts
+++ b/__tests__/unit/lib/ai-team/librarian/tools.test.ts
@@ -280,8 +280,8 @@ describe("Knowledge Librarian Tools", () => {
 
             const result = await executeTool<MoveDocumentOutput>(moveDocumentTool, {
                 userId: user.id,
-                fromPath: "knowledge.old-path",
-                toPath: "knowledge.new-path",
+                sourceDocumentPath: "knowledge.old-path",
+                destinationDocumentPath: "knowledge.new-path",
             });
 
             expect(result.success).toBe(true);
@@ -304,8 +304,8 @@ describe("Knowledge Librarian Tools", () => {
 
             const result = await executeTool<MoveDocumentOutput>(moveDocumentTool, {
                 userId: user.id,
-                fromPath: "knowledge.nonexistent",
-                toPath: "knowledge.new-path",
+                sourceDocumentPath: "knowledge.nonexistent",
+                destinationDocumentPath: "knowledge.new-path",
             });
 
             expect(result.success).toBe(false);
@@ -331,8 +331,8 @@ describe("Knowledge Librarian Tools", () => {
 
             const result = await executeTool<MoveDocumentOutput>(moveDocumentTool, {
                 userId: user.id,
-                fromPath: "knowledge.source",
-                toPath: "knowledge.destination",
+                sourceDocumentPath: "knowledge.source",
+                destinationDocumentPath: "knowledge.destination",
             });
 
             expect(result.success).toBe(false);
@@ -358,8 +358,8 @@ describe("Knowledge Librarian Tools", () => {
             // Try to move to invalid path
             const result = await executeTool<MoveDocumentOutput>(moveDocumentTool, {
                 userId: user.id,
-                fromPath: "knowledge.source",
-                toPath: "invalid%path%format", // % not allowed in paths
+                sourceDocumentPath: "knowledge.source",
+                destinationDocumentPath: "invalid%path%format", // % not allowed in paths
             });
 
             expect(result.success).toBe(false);

--- a/lib/ai-team/librarian/conversational.ts
+++ b/lib/ai-team/librarian/conversational.ts
@@ -245,12 +245,19 @@ export function createConversationalTools(userId: string) {
 
         moveDocument: tool({
             description:
-                "Move a document from one path to another. Useful for reorganizing.",
+                "Move a document from one location to another. Use sourceDocumentPath for the current location and destinationDocumentPath for the new location.",
             inputSchema: z.object({
-                fromPath: z.string().describe("Current document path"),
-                toPath: z.string().describe("New document path"),
+                sourceDocumentPath: z
+                    .string()
+                    .describe("Current path of the document to move"),
+                destinationDocumentPath: z
+                    .string()
+                    .describe("New path where the document should be moved to"),
             }),
-            execute: async ({ fromPath, toPath }) => {
+            execute: async ({
+                sourceDocumentPath: fromPath,
+                destinationDocumentPath: toPath,
+            }) => {
                 let createdAtToPath = false;
 
                 try {

--- a/lib/ai-team/librarian/tools.ts
+++ b/lib/ai-team/librarian/tools.ts
@@ -238,13 +238,19 @@ export const appendToDocumentTool = tool({
  */
 export const moveDocumentTool = tool({
     description:
-        "Move a document from one path to another. This is useful for reorganizing knowledge or correcting misplaced documents.",
+        "Move a document from one location to another. Use sourceDocumentPath for the current location and destinationDocumentPath for the new location.",
     inputSchema: z.object({
         userId: z.string().describe("User ID"),
-        fromPath: z.string().describe("Current document path"),
-        toPath: z.string().describe("New document path"),
+        sourceDocumentPath: z.string().describe("Current path of the document to move"),
+        destinationDocumentPath: z
+            .string()
+            .describe("New path where the document should be moved to"),
     }),
-    execute: async ({ userId, fromPath, toPath }): Promise<MoveDocumentOutput> => {
+    execute: async ({
+        userId,
+        sourceDocumentPath: fromPath,
+        destinationDocumentPath: toPath,
+    }): Promise<MoveDocumentOutput> => {
         // Track if we created a document at toPath (for rollback safety)
         let createdAtToPath = false;
 


### PR DESCRIPTION
## Summary
- LLM was calling `moveDocument` with `path` instead of `fromPath`, causing validation errors
- Renamed parameters to be unambiguous: `sourceDocumentPath` and `destinationDocumentPath`
- These longer names clearly distinguish from `path` used in other tools like `readDocument`

## Changes
- `lib/ai-team/librarian/tools.ts` - Renamed `fromPath`→`sourceDocumentPath`, `toPath`→`destinationDocumentPath`
- `lib/ai-team/librarian/conversational.ts` - Same rename
- Updated tests to use new parameter names

## Test plan
- [x] All 17 librarian tool tests pass
- [x] Full test suite passes (2163 tests)
- [x] Type check passes

Generated with Carmenta