### PR TITLE
🐛 Add smsUser tool to main chat route

### DIFF
--- a/app/api/connection/route.ts
+++ b/app/api/connection/route.ts
@@ -51,6 +51,7 @@ import {
     createSearchKnowledgeTool,
     createImageTool,
 } from "@/lib/tools/built-in";
+import { createSmsUserTool } from "@/lib/ai-team/agents/sms-user-tool";
 import { postResponseTools } from "@/lib/tools/post-response";
 import {
     unauthorizedResponse,
@@ -583,6 +584,13 @@ export async function POST(req: Request) {
         // Higher reasoning level = higher quality (and more expensive) image model
         const imageTool = createImageTool({ reasoning: concierge.reasoning });
 
+        // Create SMS tool for Carmenta to text the user
+        // This is system-level messaging (Carmenta → user), not the user's own Quo account
+        const smsUserTool = createSmsUserTool({
+            userId: dbUser.id,
+            userEmail: userEmail!,
+        });
+
         // Discovery mode is disabled until we refine the experience
         // It was interrupting substantive responses and degrading quality
         // TODO: Re-enable when discovery is less intrusive
@@ -596,6 +604,7 @@ export async function POST(req: Request) {
             ...postResponseTools,
             searchKnowledge: searchKnowledgeTool,
             createImage: imageTool,
+            smsUser: smsUserTool,
             ...discoveryTools,
         };
 

--- a/lib/integrations/AGENTS.md
+++ b/lib/integrations/AGENTS.md
@@ -1,0 +1,54 @@
+# Integrations - User-Connected External Services
+
+**These are the user's OWN accounts, not Carmenta's system-level capabilities.**
+
+## What This Directory Does
+
+The integrations system allows users to connect their external accounts (Gmail, Slack,
+Notion, Quo, etc.) so Carmenta can interact with those services on their behalf.
+
+- Users provide their own credentials (OAuth or API key)
+- Tools only appear when the user has connected the service
+- Carmenta acts as the user, with their permissions
+
+## Two Quo Systems - Critical Distinction
+
+Carmenta has TWO separate SMS/Quo capabilities:
+
+| System                   | Directory                                 | Purpose                                  | Credentials                           |
+| ------------------------ | ----------------------------------------- | ---------------------------------------- | ------------------------------------- |
+| **Integration Adapter**  | `lib/integrations/adapters/quo.ts` (here) | Users send SMS via their own Quo account | User's API key                        |
+| **Notification Service** | `lib/sms/`                                | Carmenta texts users proactively         | Carmenta's `QUO_NOTIFICATION_API_KEY` |
+
+### The Quo Adapter (This Directory)
+
+When a user connects their Quo account:
+
+- They provide their own Quo API key
+- Carmenta can send SMS from **their** phone number
+- Messages come from the user's business phone, not Carmenta
+
+### Carmenta's Notification Service (lib/sms/)
+
+When Carmenta needs to proactively text a user:
+
+- Uses Carmenta's own Quo credentials (`QUO_NOTIFICATION_API_KEY`)
+- Messages come from Carmenta's phone number
+- Requires user to have a verified phone number on file
+
+## Key Files
+
+- `services.ts` - Service registry (available integrations)
+- `connection-manager.ts` - OAuth/API key storage and retrieval
+- `tools.ts` - Creates Vercel AI SDK tools for connected services
+- `adapters/` - Service-specific implementations
+
+## How Tools Get Exposed
+
+`getIntegrationTools(userEmail)` returns tools only for services the user has connected.
+Called from:
+
+- Main chat route (`app/api/connection/route.ts`)
+- DCOS agent (`lib/ai-team/dcos/agent.ts`)
+
+If a service isn't showing up for a user, they likely haven't connected it yet.

--- a/lib/integrations/CLAUDE.md
+++ b/lib/integrations/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/lib/sms/AGENTS.md
+++ b/lib/sms/AGENTS.md
@@ -1,0 +1,49 @@
+# SMS - Carmenta's System-Level Messaging
+
+**This is Carmenta sending messages TO users, not users sending messages via their own
+accounts.**
+
+## Two SMS Systems in Carmenta
+
+Carmenta has TWO separate SMS capabilities. They serve different purposes:
+
+| System                   | Directory                          | Purpose                                  | Credentials                           |
+| ------------------------ | ---------------------------------- | ---------------------------------------- | ------------------------------------- |
+| **Notification Service** | `lib/sms/` (here)                  | Carmenta texts users proactively         | Carmenta's `QUO_NOTIFICATION_API_KEY` |
+| **Integration Adapter**  | `lib/integrations/adapters/quo.ts` | Users send SMS via their own Quo account | User's API key                        |
+
+## This Directory: Notification Service
+
+The notification service enables Carmenta to proactively reach users via SMS:
+
+- **Scheduled agent results** - Background tasks completing
+- **Alerts** - Important events or changes
+- **Briefings** - Daily/weekly summaries
+- **Reminders** - Time-based notifications
+
+### Key Files
+
+- `quo-notification-service.ts` - Send notifications, track delivery, handle retries
+- `index.ts` - Module exports
+
+### How It's Exposed to the Model
+
+The `smsUser` tool in `lib/ai-team/agents/sms-user-tool.ts` wraps this service. It's
+included in:
+
+- Main chat route (`app/api/connection/route.ts`)
+- DCOS agent (`lib/ai-team/dcos/agent.ts`)
+
+### Requirements
+
+For Carmenta to send SMS:
+
+1. `QUO_NOTIFICATION_API_KEY` env var must be set (Carmenta's API key)
+2. `QUO_PHONE_NUMBER` env var must be set (Carmenta's phone number)
+3. User must have a **verified, opted-in** phone number in their profile
+
+### The Other System
+
+If you're looking for **users sending SMS via their own Quo account**, see
+`lib/integrations/adapters/quo.ts`. That's the integration adapter - a completely
+separate system where users connect their own Quo credentials.

--- a/lib/sms/CLAUDE.md
+++ b/lib/sms/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary

- Fixed bug where `smsUser` tool was only available to DCOS scheduled agents, not the main chat
- When users asked Carmenta to "send a text", the model genuinely didn't have access to the SMS capability
- Added documentation to clarify the two separate quo/SMS systems in the codebase

## Changes

**Bug fix:**
- Added `createSmsUserTool` import and instantiation in `app/api/connection/route.ts`
- Added `smsUser` to the `allTools` object passed to `streamText()`

**Documentation:**
- `lib/sms/AGENTS.md` - Documents Carmenta's notification service (system → user messaging)
- `lib/integrations/AGENTS.md` - Documents user's connected accounts (user's own credentials)
- Both files include a comparison table making the distinction clear

## Test plan

- [x] Type check passes
- [x] All 2163 tests pass
- [ ] Manual test: Ask Carmenta to send a text message (requires verified phone number)

Generated with Carmenta