### PR TITLE
🐛 Fix librarian context overflow on long conversations

### DIFF
--- a/__tests__/unit/lib/ai-team/librarian/truncation.test.ts
+++ b/__tests__/unit/lib/ai-team/librarian/truncation.test.ts
@@ -152,6 +152,27 @@ describe("Librarian Truncation", () => {
             expect(result.content.length).toBeGreaterThan(0);
         });
 
+        it("should trim huge chunks when few chunks exceed limit", () => {
+            // Two huge chunks that would exceed maxTokens even with truncation notice
+            // Each chunk is ~500 chars, ~145 tokens
+            const chunk1 = "x".repeat(500);
+            const chunk2 = "y".repeat(500);
+            const content = `${chunk1}\n\n${chunk2}`;
+
+            // Set limit that forces trimming even after taking last 2 chunks
+            // Content is ~1000 chars, ~285 tokens, but we limit to 100
+            const result = truncateConversationContent(content, 100);
+
+            expect(result.wasTruncated).toBe(true);
+            expect(result.truncatedTokens).toBeLessThanOrEqual(100);
+            // Should include truncation notice
+            expect(result.content).toContain(
+                "[Earlier conversation truncated for length]"
+            );
+            // Should have trimmed content to fit
+            expect(result.content.length).toBeLessThan(content.length);
+        });
+
         it("should add truncation notice", () => {
             // Create longer chunks to ensure truncation triggers
             const chunks = Array.from(


### PR DESCRIPTION
## Summary

Fixes #705

The Knowledge Librarian was failing silently when processing conversations that exceeded the model's context limit (Haiku 4.5 @ 200K tokens). Long conversations—ironically the most valuable for knowledge extraction—would fail completely without user notification.

**Changes:**
- Add smart truncation before sending to librarian
- Detect context overflow errors and return degraded result instead of permanent error
- Log truncation metrics for observability
- Add comprehensive test coverage (24 new tests)

## Implementation

**Truncation strategy** (preserves most valuable content):
1. First chunk (conversation context/topic)
2. Last 30% of chunks (recency bias)
3. Chunks with "remember this", "important:", etc. markers
4. Truncate from middle

**Error handling:**
- Context overflow detected by error message patterns
- Returns `degradedResult` instead of `errorResult` 
- Summary indicates partial extraction so user knows

## Design Decisions

**Keep Haiku 4.5 instead of switching to larger model**: Most conversations fit fine within 200K. Switching to Gemini 2M for all extractions would increase costs significantly for rare edge cases. Smart truncation handles the overflow gracefully.

**80% safety margin**: Leave room for system prompt (~3-5K), tool definitions, and agent output. Better to truncate slightly more than risk overflow.

**Preserve patterns**: The regex patterns match explicit user requests to save info. These are the highest-value content to preserve during truncation.

## Test plan

- [x] `pnpm test librarian` - All 48 tests pass
- [x] `pnpm test truncation.test.ts` - 24 new tests covering:
  - Preserve marker detection
  - Truncation boundaries
  - Context overflow error detection
  - Edge cases (few chunks, extreme limits)
- [x] Full test suite passes (2239 tests)
- [x] TypeScript compiles cleanly

Generated with Carmenta