### PR TITLE
🐛 Return structured error for IntegrationRequired UI

### DIFF
--- a/lib/integrations/adapters/google-workspace-files.ts
+++ b/lib/integrations/adapters/google-workspace-files.ts
@@ -225,13 +225,12 @@ export class GoogleWorkspaceFilesAdapter extends ServiceAdapter {
                     : "Integration not connected";
 
             // Return structured error for UI to render IntegrationRequired component
-            // Use createResponse to preserve isError: true while providing structured data
-            return this.createResponse(tokenResult.content, {
-                isError: true,
-                structuredContent: {
-                    error: "integration_not_connected",
-                    message: errorMessage,
-                },
+            // We use isError: false so lib/integrations/tools.ts parses the JSON response.
+            // When isError: true, tools.ts returns { error: true, message: "..." } which breaks
+            // the UI check for output.error === "integration_not_connected" (string value).
+            return this.createJSONResponse({
+                error: "integration_not_connected",
+                message: errorMessage,
             });
         }
         const { accessToken } = tokenResult;


### PR DESCRIPTION
## Summary

Fix for the `IntegrationRequired` UI component never rendering when Google Workspace integration is disconnected.

**Root cause:** The adapter returned a plain text error when credentials were missing, but the UI expected a structured JSON response with `error: "integration_not_connected"`.

**Fix:** Changed the OAuth token check to return the expected JSON structure so the UI correctly renders the amber warning box with "Connect your Google account" link.

## Context

From testing with Claude for Chrome, when the integration was disconnected:
- **Expected:** Amber warning box with plug icon and connection link  
- **Actual:** AI responded conversationally instead of the rich error UI rendering

This was because `getOAuthAccessToken` returned a text error, but `GoogleWorkspaceFilesToolResult` checks for `output.error === "integration_not_connected"`.

## Test plan

- [x] TypeScript compiles
- [x] All 2215 tests pass
- [ ] Disconnect Google Workspace integration
- [ ] Ask to open a Google Sheet
- [ ] Verify amber IntegrationRequired component renders (not just text)

Generated with Carmenta