### PR TITLE
Wire PWA mobile enhancement hooks into UI

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import { ClerkProvider } from "@clerk/nextjs";
 import { UserProvider } from "@/lib/auth/user-context";
 import { ThemeProvider } from "@/lib/theme";
 import { PWARegistration } from "@/components/pwa-registration";
-import { InstallPrompt, WcoTitlebar } from "@/components/pwa";
+import { InstallPrompt, SwipeNavigationProvider, WcoTitlebar } from "@/components/pwa";
 import { StructuredData } from "@/components/seo/structured-data";
 import { clerkAppearance } from "@/lib/clerk-appearance";
 import { PostHogProvider } from "@/components/analytics/posthog-provider";
@@ -154,6 +154,7 @@ export default function RootLayout({
                                         <CarmentaModalProvider>
                                             <PWARegistration />
                                             <InstallPrompt />
+                                            <SwipeNavigationProvider />
                                             <WcoTitlebar />
                                             <StructuredData />
                                             <Toaster />

--- a/components/pwa/index.ts
+++ b/components/pwa/index.ts
@@ -1,4 +1,6 @@
 export { InstallPrompt } from "./install-prompt";
+export { OnboardingHint } from "./onboarding-hint";
 export { PullToRefreshIndicator } from "./pull-to-refresh-indicator";
 export { SwipeBackIndicator } from "./swipe-back-indicator";
+export { SwipeNavigationProvider } from "./swipe-navigation-provider";
 export { WcoTitlebar } from "./wco-titlebar";

--- a/components/pwa/onboarding-hint.tsx
+++ b/components/pwa/onboarding-hint.tsx
@@ -1,0 +1,100 @@
+/**
+ * Onboarding Hint Component
+ *
+ * Reusable progressive disclosure hint that shows a configurable number
+ * of times before hiding permanently. Uses use-hint-storage for persistence.
+ *
+ * @see knowledge/components/pwa-mobile-enhancements.md
+ */
+
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+import { XIcon, LightbulbIcon } from "@phosphor-icons/react";
+import { useHintStorage } from "@/lib/hooks/use-hint-storage";
+import { cn } from "@/lib/utils";
+
+interface OnboardingHintProps {
+    /** Unique identifier for this hint (used for localStorage) */
+    hintKey: string;
+    /** Content to display in the hint */
+    children: React.ReactNode;
+    /** Maximum times to show hint before hiding permanently (default: 3) */
+    maxShows?: number;
+    /** Expiration in days - reset hint after this many days (optional) */
+    expiresAfterDays?: number;
+    /** Position relative to trigger element */
+    position?: "top" | "bottom" | "left" | "right";
+    /** Additional class names */
+    className?: string;
+    /** Icon to display (default: LightbulbIcon) */
+    icon?: React.ReactNode;
+    /** Callback when hint is dismissed */
+    onDismiss?: () => void;
+}
+
+export function OnboardingHint({
+    hintKey,
+    children,
+    maxShows = 3,
+    expiresAfterDays,
+    position = "bottom",
+    className,
+    icon,
+    onDismiss,
+}: OnboardingHintProps) {
+    const [shouldShow, markSeen] = useHintStorage(hintKey, {
+        maxShows,
+        expiresAfterDays,
+    });
+
+    const handleDismiss = () => {
+        markSeen();
+        onDismiss?.();
+    };
+
+    const positionClasses = {
+        top: "bottom-full mb-2",
+        bottom: "top-full mt-2",
+        left: "right-full mr-2",
+        right: "left-full ml-2",
+    };
+
+    return (
+        <AnimatePresence>
+            {shouldShow && (
+                <motion.div
+                    initial={{
+                        opacity: 0,
+                        y: position === "top" ? 8 : -8,
+                        scale: 0.95,
+                    }}
+                    animate={{ opacity: 1, y: 0, scale: 1 }}
+                    exit={{ opacity: 0, y: position === "top" ? 8 : -8, scale: 0.95 }}
+                    transition={{ type: "spring", damping: 25, stiffness: 300 }}
+                    className={cn(
+                        "z-tooltip absolute",
+                        positionClasses[position],
+                        className
+                    )}
+                >
+                    <div className="bg-background/95 flex max-w-xs items-start gap-2 rounded-lg border border-white/10 p-3 shadow-lg backdrop-blur-xl">
+                        <div className="text-primary flex-shrink-0">
+                            {icon ?? <LightbulbIcon className="h-4 w-4" />}
+                        </div>
+                        <div className="text-foreground/80 flex-1 text-sm">
+                            {children}
+                        </div>
+                        <button
+                            onClick={handleDismiss}
+                            className="text-foreground/40 hover:text-foreground/60 flex-shrink-0 transition-colors"
+                            aria-label="Dismiss hint"
+                        >
+                            <XIcon className="h-4 w-4" />
+                        </button>
+                    </div>
+                </motion.div>
+            )}
+        </AnimatePresence>
+    );
+}

--- a/components/pwa/swipe-navigation-provider.tsx
+++ b/components/pwa/swipe-navigation-provider.tsx
@@ -1,0 +1,25 @@
+/**
+ * Swipe Navigation Provider
+ *
+ * Client wrapper that wires useSwipeNavigation hook to SwipeBackIndicator.
+ * Add to root layout for global swipe-from-edge back navigation.
+ *
+ * @see knowledge/components/pwa-mobile-enhancements.md
+ */
+
+"use client";
+
+import { useSwipeNavigation } from "@/lib/hooks/use-swipe-navigation";
+import { SwipeBackIndicator } from "./swipe-back-indicator";
+
+export function SwipeNavigationProvider() {
+    const { swipeDistance, isSwiping, progress } = useSwipeNavigation();
+
+    return (
+        <SwipeBackIndicator
+            progress={progress}
+            isSwiping={isSwiping}
+            swipeDistance={swipeDistance}
+        />
+    );
+}


### PR DESCRIPTION
## Summary

Wire up the PWA mobile enhancement hooks that were built but never integrated:

- **SwipeNavigationProvider**: Added to root layout - provides iOS-like swipe-from-edge back navigation
- **OnboardingHint**: New reusable component wrapping `use-hint-storage` for progressive disclosure hints
- **InstallPrompt**: Already integrated with custom engagement logic (intentional per existing implementation)

## Design Decisions

**SwipeNavigationProvider as a wrapper component**: Rather than adding hook logic directly to layout.tsx (which is a server component), created a client wrapper that cleanly composes `useSwipeNavigation` with `SwipeBackIndicator`. This keeps the layout clean and makes the integration testable.

**OnboardingHint with position prop**: Designed to work with relative positioning so hints can appear above/below/left/right of trigger elements. Uses Framer Motion animations matching other Carmenta components.

**use-hint-storage hook unchanged**: The hook is well-designed as-is. OnboardingHint just provides a UI component that demonstrates the pattern.

## Testing

- All 2296 tests pass
- Type checking passes
- Lint/format passes
- Manual testing required on iOS PWA and Android (noted in issue)

Fixes #718

Generated with Carmenta