### PR TITLE
✨ Add GITGUARD_CONFIRMED flag for explicit push/merge approval

### DIFF
--- a/.claude/hooks/git-guard.py
+++ b/.claude/hooks/git-guard.py
@@ -63,14 +63,15 @@ def has_confirmation_flag(command: str) -> bool:
     try:
         tokens = shlex.split(command)
 
-        # Scan tokens up to the git command, handling cd && ... prefixes
-        # We need to check env vars that appear before 'git', even if there's
+        # Scan tokens up to the git/gh command, handling cd && ... prefixes
+        # We need to check env vars that appear before 'git' or 'gh', even if there's
         # a cd or other command before them (e.g., "cd /repo && GITGUARD_CONFIRMED=1 git push")
         for i, token in enumerate(tokens):
             if token == "GITGUARD_CONFIRMED=1":
                 return True
-            # Stop searching once we hit the actual git command
-            if token == "git":
+            # Stop searching once we hit the actual git or gh command
+            # This prevents suffix bypass like "gh pr merge 123 GITGUARD_CONFIRMED=1"
+            if token in ("git", "gh"):
                 break
             # Continue past command separators like &&
             if token in ("&&", "||", ";"):

--- a/.claude/hooks/test-git-guard.py
+++ b/.claude/hooks/test-git-guard.py
@@ -377,6 +377,20 @@ def test_confirmation_flag_parsing():
         "cd /tmp ; GITGUARD_CONFIRMED=1 git push → allowed (semicolon separator)"
     )
 
+    # Security test: flag AFTER command (suffix bypass attempt) should be blocked
+    exit_code, _, stderr = run_hook("gh pr merge 123 GITGUARD_CONFIRMED=1")
+    results.check(
+        exit_code == 2,
+        "gh pr merge 123 GITGUARD_CONFIRMED=1 → blocked (suffix bypass attempt)"
+    )
+
+    # Same for git
+    exit_code, _, stderr = run_hook("git push origin main GITGUARD_CONFIRMED=1")
+    results.check(
+        exit_code == 2,
+        "git push origin main GITGUARD_CONFIRMED=1 → blocked (suffix bypass attempt)"
+    )
+
     return results
 
 


### PR DESCRIPTION
## Summary

Changes GitGuard hook behavior for push-to-main and PR merge operations:

- **Before:** `ASK_USER` - triggers permission dialog every time
- **After:** `NEEDS_CONFIRMATION` - blocks unless `GITGUARD_CONFIRMED=1` prefix is set

This allows Claude to:
- Set the flag immediately when user explicitly asks ("push to main") → zero friction
- Omit the flag when acting autonomously → hook blocks, Claude can then ask

## Changes

- Renamed `ASK_USER` violation type to `NEEDS_CONFIRMATION`
- Added `has_confirmation_flag()` to detect `GITGUARD_CONFIRMED=1` prefix
- Updated main logic: block without flag, allow with flag
- Hard blocks (`--no-verify`, `-a`) remain never bypassable even with the flag
- Comprehensive tests for the new behavior

## Test plan

- [x] Unit tests pass (37 tests)
- [x] `git push origin main` → blocked with helpful message
- [x] `GITGUARD_CONFIRMED=1 git push origin main` → allowed
- [x] `GITGUARD_CONFIRMED=1 git commit -a` → still hard blocked (can't bypass)

Generated with Carmenta