### PR TITLE
⚡ Enable parallel E2E test execution (4 workers)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -22,7 +22,8 @@ export default defineConfig({
     // 1 retry on CI for infrastructure flakiness (browser crashes, network blips)
     // Local stays at 0 - flaky tests should fail loudly during development
     retries: process.env.CI ? 1 : 0,
-    workers: process.env.CI ? 1 : undefined,
+    // Parallel execution - tests are stateless page loads, no shared DB writes
+    workers: process.env.CI ? 4 : undefined,
     reporter: "html",
 
     // Timeouts optimized for CI (cold start) and local (warm cache)


### PR DESCRIPTION
## Summary
- Change E2E test workers from 1 to 4 in CI
- Tests are stateless page loads with no shared DB writes

## Why This Should Work
Looking at the test files:
- `public-access.test.ts` - HTTP status checks, no DB
- `guards.test.ts` - Redirect verification, no DB writes
- `assets.test.ts` - Static file checks
- `seo.test.ts` - robots.txt, sitemap validation
- `oauth-flows.test.ts` - URL validation only
- `viewports.test.ts` - Viewport rendering
- `error-pages.test.ts` - 404/500 page checks
- `smoke.test.ts` - Basic health check

Each test creates its own browser context via Playwright's `fullyParallel: true`.

## Expected Result
E2E job: ~7min → ~2-3min (compile time is amortized across 4 workers)

## Test Plan
- [ ] CI build passes
- [ ] Compare E2E job timing vs previous runs

Generated with Carmenta