### PR TITLE
🐛 Fix image context overflow and standardize tooltips

### DIFF
--- a/components/carmenta-assistant/carmenta-layout.tsx
+++ b/components/carmenta-assistant/carmenta-layout.tsx
@@ -28,6 +28,7 @@ import { SparkleIcon, CaretLeftIcon, Trash } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCarmentaModal } from "@/hooks/use-carmenta-modal";
 import { ConnectRuntimeProvider, useChatContext } from "@/components/connection";
 import { HoloThread } from "@/components/connection/holo-thread";
@@ -205,14 +206,18 @@ function DesktopPanel({ onClose }: { onClose: () => void }) {
 
                 <div className="flex items-center gap-2">
                     {messages.length > 0 && (
-                        <button
-                            onClick={handleClear}
-                            className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors"
-                            aria-label="Clear conversation"
-                            title="Clear conversation"
-                        >
-                            <Trash className="h-4 w-4" />
-                        </button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <button
+                                    onClick={handleClear}
+                                    className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors"
+                                    aria-label="Clear conversation"
+                                >
+                                    <Trash className="h-4 w-4" />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Clear conversation</TooltipContent>
+                        </Tooltip>
                     )}
                     <button
                         onClick={onClose}

--- a/components/carmenta-assistant/carmenta-panel.tsx
+++ b/components/carmenta-assistant/carmenta-panel.tsx
@@ -16,6 +16,7 @@ import { SparkleIcon, CaretLeftIcon, TrashIcon } from "@phosphor-icons/react";
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
 import { useChatScroll } from "@/lib/hooks/use-chat-scroll";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
     SimpleComposer,
     UserBubble,
@@ -144,14 +145,20 @@ export function CarmentaPanel({
                             <div className="flex items-center gap-2">
                                 {/* Clear conversation */}
                                 {messages.length > 0 && (
-                                    <button
-                                        onClick={clear}
-                                        className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors"
-                                        aria-label="Clear conversation"
-                                        title="Clear conversation"
-                                    >
-                                        <TrashIcon className="h-4 w-4" />
-                                    </button>
+                                    <Tooltip>
+                                        <TooltipTrigger asChild>
+                                            <button
+                                                onClick={clear}
+                                                className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-11 min-w-11 items-center justify-center rounded-lg transition-colors"
+                                                aria-label="Clear conversation"
+                                            >
+                                                <TrashIcon className="h-4 w-4" />
+                                            </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                            Clear conversation
+                                        </TooltipContent>
+                                    </Tooltip>
                                 )}
 
                                 {/* Collapse button */}

--- a/components/carmenta-assistant/carmenta-sheet.tsx
+++ b/components/carmenta-assistant/carmenta-sheet.tsx
@@ -23,6 +23,7 @@
 
 import { Sparkle, Trash } from "@phosphor-icons/react";
 
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
     Sheet,
     SheetContent,
@@ -122,14 +123,18 @@ function CarmentaSheetInner({
 
                 <div className="flex items-center gap-1">
                     {messages.length > 0 && (
-                        <button
-                            onClick={handleClear}
-                            className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-9 min-w-9 items-center justify-center rounded-lg transition-colors"
-                            aria-label="Clear conversation"
-                            title="Clear conversation"
-                        >
-                            <Trash className="h-4 w-4" />
-                        </button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <button
+                                    onClick={handleClear}
+                                    className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-9 min-w-9 items-center justify-center rounded-lg transition-colors"
+                                    aria-label="Clear conversation"
+                                >
+                                    <Trash className="h-4 w-4" />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Clear conversation</TooltipContent>
+                        </Tooltip>
                     )}
                 </div>
             </SheetHeader>

--- a/components/carmenta-assistant/carmenta-sidecar.tsx
+++ b/components/carmenta-assistant/carmenta-sidecar.tsx
@@ -25,6 +25,7 @@ import Image from "next/image";
 
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
     Sheet,
     SheetContent,
@@ -373,14 +374,18 @@ function SidecarInner({
 
                 <div className="flex items-center gap-1">
                     {messages.length > 0 && (
-                        <button
-                            onClick={handleClear}
-                            className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-9 min-w-9 items-center justify-center rounded-lg transition-colors"
-                            aria-label="Clear conversation"
-                            title="Clear conversation"
-                        >
-                            <Trash className="h-4 w-4" />
-                        </button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <button
+                                    onClick={handleClear}
+                                    className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-9 min-w-9 items-center justify-center rounded-lg transition-colors"
+                                    aria-label="Clear conversation"
+                                >
+                                    <Trash className="h-4 w-4" />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent>Clear conversation</TooltipContent>
+                        </Tooltip>
                     )}
                     <button
                         onClick={onClose}

--- a/components/carmenta-modal/index.tsx
+++ b/components/carmenta-modal/index.tsx
@@ -15,6 +15,7 @@ import { SparkleIcon, Trash } from "@phosphor-icons/react";
 
 import { cn } from "@/lib/utils";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { useCarmentaModal } from "@/hooks/use-carmenta-modal";
 import { ConnectRuntimeProvider, useChatContext } from "@/components/connection";
 import { HoloThread } from "@/components/connection/holo-thread";
@@ -68,14 +69,18 @@ function CarmentaModalInner() {
                 </div>
 
                 {messages.length > 0 && (
-                    <button
-                        onClick={handleClear}
-                        className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-9 min-w-9 items-center justify-center rounded-lg transition-colors"
-                        aria-label="Clear conversation"
-                        title="Clear conversation"
-                    >
-                        <Trash className="h-4 w-4" />
-                    </button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <button
+                                onClick={handleClear}
+                                className="text-foreground/40 hover:bg-foreground/5 hover:text-foreground/60 flex min-h-9 min-w-9 items-center justify-center rounded-lg transition-colors"
+                                aria-label="Clear conversation"
+                            >
+                                <Trash className="h-4 w-4" />
+                            </button>
+                        </TooltipTrigger>
+                        <TooltipContent>Clear conversation</TooltipContent>
+                    </Tooltip>
                 )}
             </div>
 

--- a/components/tools/integrations/create-image.tsx
+++ b/components/tools/integrations/create-image.tsx
@@ -20,6 +20,7 @@ import { logger } from "@/lib/client-logger";
 import { ImageGenerationLoader } from "@/components/ui/image-generation-loader";
 import { CopyImageButton } from "@/components/ui/copy-image-button";
 import { DownloadImageButton } from "@/components/ui/download-image-button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 /** Allowed MIME types for generated images */
 const ALLOWED_MIME_TYPES = ["image/png", "image/jpeg", "image/webp"] as const;
@@ -401,13 +402,18 @@ function ImageCard({
                             ariaLabel="Download image"
                             size="sm"
                         />
-                        <button
-                            onClick={() => setLightboxOpen(true)}
-                            className="rounded-md bg-black/50 p-2 text-white/80 backdrop-blur-sm transition-colors hover:bg-black/70 hover:text-white"
-                            title="View fullscreen"
-                        >
-                            <ArrowsOutIcon className="h-4 w-4" />
-                        </button>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <button
+                                    onClick={() => setLightboxOpen(true)}
+                                    className="rounded-md bg-black/50 p-2 text-white/80 backdrop-blur-sm transition-colors hover:bg-black/70 hover:text-white"
+                                    aria-label="View fullscreen"
+                                >
+                                    <ArrowsOutIcon className="h-4 w-4" />
+                                </button>
+                            </TooltipTrigger>
+                            <TooltipContent>View fullscreen</TooltipContent>
+                        </Tooltip>
                     </div>
 
                     {/* Bottom info - on hover (desktop) or always (mobile) */}

--- a/components/ui/copy-image-button.tsx
+++ b/components/ui/copy-image-button.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { transitions } from "@/lib/motion/presets";
 import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 import { logger } from "@/lib/client-logger";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 /**
  * Delight messages for image copy - themed around visual creation.
@@ -159,32 +160,40 @@ export function CopyImageButton({
     );
 
     return (
-        <motion.button
-            onClick={handleCopy}
-            aria-label={copied ? message || "Copied!" : ariaLabel}
-            layout
-            className={buttonClasses}
-            title={ariaLabel}
-        >
-            {copied ? (
-                <>
-                    <CheckIcon className={cn(iconSize, "flex-shrink-0")} />
-                    {message && size === "md" && (
-                        <motion.span
-                            initial={{ opacity: 0, width: 0, marginLeft: 0 }}
-                            animate={{ opacity: 1, width: "auto", marginLeft: 6 }}
-                            exit={{ opacity: 0, width: 0, marginLeft: 0 }}
-                            transition={transitions.quick}
-                            className="text-xs font-medium whitespace-nowrap"
-                            aria-live="polite"
-                        >
-                            {message}
-                        </motion.span>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <motion.button
+                    onClick={handleCopy}
+                    aria-label={copied ? message || "Copied!" : ariaLabel}
+                    layout
+                    className={buttonClasses}
+                >
+                    {copied ? (
+                        <>
+                            <CheckIcon className={cn(iconSize, "flex-shrink-0")} />
+                            {message && size === "md" && (
+                                <motion.span
+                                    initial={{ opacity: 0, width: 0, marginLeft: 0 }}
+                                    animate={{
+                                        opacity: 1,
+                                        width: "auto",
+                                        marginLeft: 6,
+                                    }}
+                                    exit={{ opacity: 0, width: 0, marginLeft: 0 }}
+                                    transition={transitions.quick}
+                                    className="text-xs font-medium whitespace-nowrap"
+                                    aria-live="polite"
+                                >
+                                    {message}
+                                </motion.span>
+                            )}
+                        </>
+                    ) : (
+                        <CopyIcon className={iconSize} />
                     )}
-                </>
-            ) : (
-                <CopyIcon className={iconSize} />
-            )}
-        </motion.button>
+                </motion.button>
+            </TooltipTrigger>
+            <TooltipContent>{ariaLabel}</TooltipContent>
+        </Tooltip>
     );
 }

--- a/components/ui/download-image-button.tsx
+++ b/components/ui/download-image-button.tsx
@@ -17,6 +17,7 @@ import { cn } from "@/lib/utils";
 import { transitions } from "@/lib/motion/presets";
 import { useHapticFeedback } from "@/lib/hooks/use-haptic-feedback";
 import { logger } from "@/lib/client-logger";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 /** Duration to show success feedback before resetting */
 const FEEDBACK_DURATION_MS = 2000;
@@ -140,32 +141,40 @@ export function DownloadImageButton({
     );
 
     return (
-        <motion.button
-            onClick={handleDownload}
-            aria-label={downloaded ? "Downloaded!" : ariaLabel}
-            layout
-            className={buttonClasses}
-            title={ariaLabel}
-        >
-            {downloaded ? (
-                <>
-                    <CheckIcon className={cn(iconSize, "flex-shrink-0")} />
-                    {size === "md" && (
-                        <motion.span
-                            initial={{ opacity: 0, width: 0, marginLeft: 0 }}
-                            animate={{ opacity: 1, width: "auto", marginLeft: 6 }}
-                            exit={{ opacity: 0, width: 0, marginLeft: 0 }}
-                            transition={transitions.quick}
-                            className="text-xs font-medium whitespace-nowrap"
-                            aria-live="polite"
-                        >
-                            Saved!
-                        </motion.span>
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <motion.button
+                    onClick={handleDownload}
+                    aria-label={downloaded ? "Downloaded!" : ariaLabel}
+                    layout
+                    className={buttonClasses}
+                >
+                    {downloaded ? (
+                        <>
+                            <CheckIcon className={cn(iconSize, "flex-shrink-0")} />
+                            {size === "md" && (
+                                <motion.span
+                                    initial={{ opacity: 0, width: 0, marginLeft: 0 }}
+                                    animate={{
+                                        opacity: 1,
+                                        width: "auto",
+                                        marginLeft: 6,
+                                    }}
+                                    exit={{ opacity: 0, width: 0, marginLeft: 0 }}
+                                    transition={transitions.quick}
+                                    className="text-xs font-medium whitespace-nowrap"
+                                    aria-live="polite"
+                                >
+                                    Saved!
+                                </motion.span>
+                            )}
+                        </>
+                    ) : (
+                        <DownloadIcon className={iconSize} />
                     )}
-                </>
-            ) : (
-                <DownloadIcon className={iconSize} />
-            )}
-        </motion.button>
+                </motion.button>
+            </TooltipTrigger>
+            <TooltipContent>{ariaLabel}</TooltipContent>
+        </Tooltip>
     );
 }

--- a/components/ui/image-generation-loader.tsx
+++ b/components/ui/image-generation-loader.tsx
@@ -41,32 +41,32 @@ const TASK_MODEL_INFO: Record<
     diagram: {
         model: "Gemini 3 Pro",
         shortModel: "Gemini",
-        reason: "Best for diagrams (98% in evals)",
+        reason: "AI-structured layouts",
     },
     text: {
         model: "Gemini 3 Pro",
         shortModel: "Gemini",
-        reason: "Best for text rendering (86% in evals)",
+        reason: "Clear, legible typography",
     },
     logo: {
         model: "FLUX 2 Flex",
         shortModel: "FLUX",
-        reason: "Best for logos (70% in evals)",
+        reason: "Clean lines & crisp shapes",
     },
     photo: {
         model: "Imagen 4.0 Ultra",
         shortModel: "Imagen Ultra",
-        reason: "Best for photos (70% in evals)",
+        reason: "Realistic detail & lighting",
     },
     illustration: {
         model: "Gemini 3 Pro",
         shortModel: "Gemini",
-        reason: "Best for illustrations (75% in evals)",
+        reason: "Rich artistic detail",
     },
     default: {
         model: "Imagen 4.0",
         shortModel: "Imagen",
-        reason: "Versatile general-purpose model",
+        reason: "Versatile all-rounder",
     },
 };
 


### PR DESCRIPTION
## Summary

- **Fixed image context overflow bug** - `filterLargeToolOutputs()` wasn't catching the `output.images[]` pattern returned by Image Artist, causing 500KB+ base64 data to be sent with each request
- **Standardized tooltips** - Replaced native `title=` attributes with Radix Tooltip components for consistent UX
- **Improved loader copy** - Changed eval scores to user-friendly explanations

## Changes

### Critical fix: `lib/ai/messages.ts`
The filter checked for `output.data.images[].base64` but Image Artist returns `output.images[].base64` directly. Multiple images would instantly exceed context limits (each image is 500KB-1MB of base64).

### Tooltip standardization (9 files)
- `copy-image-button.tsx`, `download-image-button.tsx`
- `create-image.tsx` (fullscreen button)
- All assistant variants: `carmenta-modal`, `carmenta-sidecar`, `carmenta-layout`, `carmenta-sheet`, `carmenta-panel`

### Loader UX: `image-generation-loader.tsx`
- "Best for logos (70% in evals)" → "Clean lines & crisp shapes"
- Users don't care about eval scores, they want to know WHY we chose that model

## Test plan
- [x] Type check passes
- [x] All 2404 tests pass
- [ ] Generate multiple images in a single conversation
- [ ] Verify no context overflow errors in Sentry

Generated with Carmenta