### PR TITLE
🐛 Fix scroll-to-bottom button z-index

### DIFF
--- a/components/chat/scroll-to-bottom-button.tsx
+++ b/components/chat/scroll-to-bottom-button.tsx
@@ -36,7 +36,7 @@ export const ScrollToBottomButton = memo(function ScrollToBottomButton({
         <button
             onClick={onScrollToBottom}
             className={cn(
-                "btn-glass-interactive z-sticky flex h-10 w-10 items-center justify-center",
+                "btn-glass-interactive z-dropdown flex h-10 w-10 items-center justify-center",
                 className
             )}
             aria-label="Scroll to bottom"


### PR DESCRIPTION
## Summary

- Fixed z-index on scroll-to-bottom button from `z-sticky` (20) to `z-dropdown` (30)
- Button was being obscured by the input container's `backdrop-blur-2xl` stacking context
- Now properly floats above the input area while remaining below modals/tooltips

## Design Decision

Chose `z-dropdown` (30) because:
- Higher than `z-sticky` (20) to appear above blurred backdrops
- Lower than `z-modal` (50) so it doesn't interfere with dialogs
- Semantic match: floating UI element similar to dropdown positioning

## Test plan

- [ ] Scroll up in a conversation - button should appear
- [ ] Button should be visible above the input area blur
- [ ] Button should not appear above modals/tooltips

Generated with Carmenta