### PR TITLE
🐛 Fix TooltipProvider missing at app level

### DIFF
--- a/__tests__/unit/components/carmenta-assistant/carmenta-sidecar.test.tsx
+++ b/__tests__/unit/components/carmenta-assistant/carmenta-sidecar.test.tsx
@@ -7,8 +7,23 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, fireEvent } from "@testing-library/react";
+import type { ReactNode } from "react";
 
 import { CarmentaSidecar } from "@/components/carmenta-assistant/carmenta-sidecar";
+import { TooltipProvider } from "@/components/ui/tooltip";
+
+/**
+ * Wrapper that provides TooltipProvider like app/layout.tsx does.
+ * Required for any component that uses Radix Tooltip.
+ */
+function TestWrapper({ children }: { children: ReactNode }) {
+    return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+/** Render with providers that app/layout.tsx provides */
+function renderWithProviders(ui: ReactNode) {
+    return render(ui, { wrapper: TestWrapper });
+}
 
 // Mock useMediaQuery to always return desktop (true)
 vi.mock("@/hooks/use-media-query", () => ({
@@ -64,7 +79,7 @@ describe("CarmentaSidecar", () => {
 
     describe("basic rendering", () => {
         it("renders on desktop when open", () => {
-            render(
+            renderWithProviders(
                 <CarmentaSidecar
                     open={true}
                     onOpenChange={() => {}}
@@ -77,7 +92,7 @@ describe("CarmentaSidecar", () => {
         });
 
         it("renders custom title and description", () => {
-            render(
+            renderWithProviders(
                 <CarmentaSidecar
                     open={true}
                     onOpenChange={() => {}}
@@ -108,7 +123,7 @@ describe("CarmentaSidecar", () => {
             mockMessages = [{ id: "1", role: "user", content: "Hello" }];
 
             // This render would throw without TooltipProvider
-            render(
+            renderWithProviders(
                 <CarmentaSidecar
                     open={true}
                     onOpenChange={() => {}}
@@ -123,7 +138,7 @@ describe("CarmentaSidecar", () => {
         it("clears messages when clear button clicked", () => {
             mockMessages = [{ id: "1", role: "user", content: "Hello" }];
 
-            render(
+            renderWithProviders(
                 <CarmentaSidecar
                     open={true}
                     onOpenChange={() => {}}
@@ -142,7 +157,7 @@ describe("CarmentaSidecar", () => {
         it("calls onOpenChange when close button clicked", () => {
             const onOpenChange = vi.fn();
 
-            render(
+            renderWithProviders(
                 <CarmentaSidecar
                     open={true}
                     onOpenChange={onOpenChange}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,6 +13,7 @@ import { PostHogProvider } from "@/components/analytics/posthog-provider";
 import { FloatingEmojiProvider } from "@/components/delight/floating-emoji";
 import { Toaster } from "sonner";
 import { GlobalTooltip } from "@/components/ui/global-tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import { CarmentaModalProvider, CarmentaModal } from "@/components/carmenta-modal";
 import "./globals.css";
 
@@ -155,19 +156,21 @@ export default function RootLayout({
                             </head>
                             <body className="bg-background min-h-screen font-sans antialiased">
                                 <ThemeProvider>
-                                    <FloatingEmojiProvider>
-                                        <CarmentaModalProvider>
-                                            <PWARegistration />
-                                            <InstallPrompt />
-                                            <SwipeNavigationProvider />
-                                            <WcoTitlebar />
-                                            <StructuredData />
-                                            <Toaster />
-                                            <GlobalTooltip />
-                                            <CarmentaModal />
-                                            {children}
-                                        </CarmentaModalProvider>
-                                    </FloatingEmojiProvider>
+                                    <TooltipProvider>
+                                        <FloatingEmojiProvider>
+                                            <CarmentaModalProvider>
+                                                <PWARegistration />
+                                                <InstallPrompt />
+                                                <SwipeNavigationProvider />
+                                                <WcoTitlebar />
+                                                <StructuredData />
+                                                <Toaster />
+                                                <GlobalTooltip />
+                                                <CarmentaModal />
+                                                {children}
+                                            </CarmentaModalProvider>
+                                        </FloatingEmojiProvider>
+                                    </TooltipProvider>
                                 </ThemeProvider>
                             </body>
                         </html>

--- a/components/AGENTS.md
+++ b/components/AGENTS.md
@@ -28,19 +28,18 @@ are acceptable—these don't participate in the page-level hierarchy.
 Two tooltip systems with consistent 400ms show delay:
 
 **Radix Tooltips** (component-based): Use for interactive triggers, complex content, or
-when you need fine-grained control. TooltipProvider defaults to 400ms delay.
+when you need fine-grained control. `TooltipProvider` is in `app/layout.tsx` at the app
+level—don't add your own.
 
 ```tsx
-<TooltipProvider>
-  <Tooltip>
-    <TooltipTrigger asChild>
-      <Button variant="ghost" size="icon">
-        <CopyIcon />
-      </Button>
-    </TooltipTrigger>
-    <TooltipContent>Copy to clipboard</TooltipContent>
-  </Tooltip>
-</TooltipProvider>
+<Tooltip>
+  <TooltipTrigger asChild>
+    <Button variant="ghost" size="icon">
+      <CopyIcon />
+    </Button>
+  </TooltipTrigger>
+  <TooltipContent>Copy to clipboard</TooltipContent>
+</Tooltip>
 ```
 
 **GlobalTooltip** (attribute-based): Use for simple text tooltips without wrapping. Add

--- a/components/carmenta-assistant/carmenta-sidecar.tsx
+++ b/components/carmenta-assistant/carmenta-sidecar.tsx
@@ -33,12 +33,7 @@ import type { UIMessage } from "@ai-sdk/react";
 
 import { cn } from "@/lib/utils";
 import { useMediaQuery } from "@/hooks/use-media-query";
-import {
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
     Sheet,
     SheetContent,
@@ -396,7 +391,7 @@ function SidecarInner({
     };
 
     return (
-        <TooltipProvider>
+        <>
             {/* Header */}
             <header className="border-foreground/[0.08] flex shrink-0 items-center justify-between border-b px-4 py-3">
                 <div className="flex items-center gap-2.5">
@@ -463,7 +458,7 @@ function SidecarInner({
                     auxiliaryContent={auxiliaryContent}
                 />
             </div>
-        </TooltipProvider>
+        </>
     );
 }
 


### PR DESCRIPTION
## Summary
- Fix crash when rendering image generation results ("Tooltip must be used within TooltipProvider")
- Move TooltipProvider from per-component to app/layout.tsx where it belongs
- Update component docs to prevent future occurrences

## What happened
Image generation was working but the UI crashed when trying to render the result. The `create-image.tsx` component uses Radix Tooltip without being wrapped in a TooltipProvider ancestor.

## Root cause
TooltipProvider was only present in `carmenta-sidecar.tsx`, not at the app level. Components rendered outside that tree (like tool results in the main chat) had no provider.

## Why it wasn't in Sentry
React rendering errors are caught by React's error boundary system *before* reaching the global error handler. Without explicit Sentry.ErrorBoundary integration, these errors stay in React-land.

## Test plan
- [x] TypeScript compiles without errors
- [x] All 2832 tests pass  
- [x] Regression test for TooltipProvider updated to use TestWrapper
- [ ] Manually verify image generation works on dev server

Generated with Carmenta