### PR TITLE
🎨 Add UI support for partial/blocked job run statuses

### DIFF
--- a/app/ai-team/page.tsx
+++ b/app/ai-team/page.tsx
@@ -13,6 +13,8 @@ import {
     WarningCircleIcon,
     CheckCircleIcon,
     BroadcastIcon,
+    CircleHalfIcon,
+    StopCircleIcon,
 } from "@phosphor-icons/react";
 import * as Sentry from "@sentry/nextjs";
 import { toast } from "sonner";
@@ -40,7 +42,7 @@ interface ActivityItem {
     jobSlug: string;
     jobEncodedId: string;
     summary: string;
-    status: "completed" | "failed" | "running";
+    status: "completed" | "failed" | "running" | "partial" | "blocked";
     completedAt: Date | null;
     notificationCount: number;
 }
@@ -660,6 +662,12 @@ function AITeamContent({
                                                         <CheckCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-green-500" />
                                                     ) : activity.status === "failed" ? (
                                                         <WarningCircleIcon className="mt-0.5 h-5 w-5 shrink-0 text-red-500" />
+                                                    ) : activity.status ===
+                                                      "partial" ? (
+                                                        <CircleHalfIcon className="mt-0.5 h-5 w-5 shrink-0 text-amber-500" />
+                                                    ) : activity.status ===
+                                                      "blocked" ? (
+                                                        <StopCircleIcon className="text-foreground/40 mt-0.5 h-5 w-5 shrink-0" />
                                                     ) : (
                                                         <SparkleIcon className="text-primary mt-0.5 h-5 w-5 shrink-0 animate-pulse" />
                                                     )}
@@ -705,9 +713,15 @@ function AITeamContent({
                                                     <span className="text-foreground/50 text-xs whitespace-nowrap">
                                                         {activity.status === "running"
                                                             ? "Running"
-                                                            : formatRelativeTime(
-                                                                  activity.completedAt
-                                                              )}
+                                                            : activity.status ===
+                                                                "partial"
+                                                              ? "Partial"
+                                                              : activity.status ===
+                                                                  "blocked"
+                                                                ? "Blocked"
+                                                                : formatRelativeTime(
+                                                                      activity.completedAt
+                                                                  )}
                                                     </span>
                                                 </div>
                                             </div>


### PR DESCRIPTION
## Summary

- Adds `partial` and `blocked` to the `ActivityItem.status` type to match the database enum added in #774
- Adds appropriate icons and styling:
  - **partial**: CircleHalfIcon with amber/orange color - indicates job ran but didn't fully complete
  - **blocked**: StopCircleIcon with muted gray color - indicates job was blocked from running
- Updates status text display to show "Partial" or "Blocked" instead of timestamps for these states

Fixes #777

## Test plan

- [x] Type-check passes
- [x] Lint passes  
- [x] All 2836 tests pass
- [ ] Visual verification: jobs with partial/blocked status display correct icons and colors

Generated with Carmenta