### PR TITLE
♻️ Refactor Google Workspace Files integration to readonly

### DIFF
--- a/components/tools/integrations/google-workspace-files.tsx
+++ b/components/tools/integrations/google-workspace-files.tsx
@@ -5,7 +5,11 @@
  *
  * Handles tool results for google-workspace-files integration:
  * - open_google_picker: Opens the Google Picker for file selection
- * - Other actions: Sheet/Doc creation confirmations
+ * - read_sheet: Reads data from a Google Sheet (handled by ToolRenderer)
+ *
+ * Note: Document creation (create_sheet, create_doc) was removed in 2025-01.
+ * Carmenta is not a document formatting service—users should create docs in
+ * Google Workspace and have Carmenta read/analyze them.
  */
 
 import { useState, useEffect, useCallback } from "react";
@@ -251,61 +255,6 @@ function PickerAction({
 }
 
 /**
- * File creation confirmation
- */
-function FileCreatedConfirmation({
-    type,
-    title,
-    url,
-}: {
-    type: "sheet" | "doc" | "slides";
-    title: string;
-    url: string;
-}) {
-    const icons = {
-        sheet: <Table className="h-5 w-5 text-green-400" />,
-        doc: <TextT className="h-5 w-5 text-blue-400" />,
-        slides: <Presentation className="h-5 w-5 text-yellow-400" />,
-    };
-
-    const typeNames = {
-        sheet: "Google Sheet",
-        doc: "Google Doc",
-        slides: "Google Slides",
-    };
-
-    // Explicit mapping for action text (avoids brittle string split)
-    const openInLabels = {
-        sheet: "Open in Sheets",
-        doc: "Open in Docs",
-        slides: "Open in Slides",
-    };
-
-    return (
-        <div className="rounded-md border border-white/10 bg-white/5 p-4">
-            <div className="flex items-center gap-2 text-sm">
-                {icons[type]}
-                <span className="font-medium text-white">
-                    Your {typeNames[type]} is ready
-                </span>
-            </div>
-            <div className="mt-3 space-y-2 text-sm">
-                <div className="font-medium text-white">{title}</div>
-                <a
-                    href={url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-2 inline-flex items-center gap-1.5 rounded text-blue-400 transition-colors hover:text-blue-300 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none"
-                >
-                    <ArrowSquareOut className="h-3.5 w-3.5" />
-                    {openInLabels[type]}
-                </a>
-            </div>
-        </div>
-    );
-}
-
-/**
  * Integration not connected message with direct link
  */
 function IntegrationRequired() {
@@ -355,37 +304,7 @@ export function GoogleWorkspaceFilesToolResult({
             return <IntegrationRequired />;
         }
 
-        // Handle file creation
-        if (output.spreadsheetId && output.url) {
-            return (
-                <FileCreatedConfirmation
-                    type="sheet"
-                    title={(input.title as string) || "Untitled Spreadsheet"}
-                    url={output.url as string}
-                />
-            );
-        }
-
-        if (output.documentId && output.url) {
-            return (
-                <FileCreatedConfirmation
-                    type="doc"
-                    title={(input.title as string) || "Untitled Document"}
-                    url={output.url as string}
-                />
-            );
-        }
-
-        if (output.presentationId && output.url) {
-            return (
-                <FileCreatedConfirmation
-                    type="slides"
-                    title={(input.title as string) || "Untitled Presentation"}
-                    url={output.url as string}
-                />
-            );
-        }
-
+        // All other outputs (read_sheet results, etc.) are handled by ToolRenderer
         return null;
     };
 

--- a/lib/integrations/services.ts
+++ b/lib/integrations/services.ts
@@ -250,25 +250,26 @@ export const SERVICE_REGISTRY: ServiceDefinition[] = [
     },
 
     // Google Sheets/Docs/Slides - OAuth (in-house, "non-sensitive" drive.file scope)
+    // Read-only: users select files via Google Picker, Carmenta reads/analyzes them
     {
         id: "google-workspace-files",
         name: "Google Sheets/Docs/Slides",
         description:
-            "Create and work with Sheets, Docs, and Slides in your Carmenta workspace",
+            "Read and analyze your Sheets, Docs, and Slides by selecting them via file picker",
         logo: "/logos/google-workspace-files.svg",
         authMethod: "oauth",
         status: "available",
         oauthProviderId: "google-workspace-files",
         supportsMultipleAccounts: true,
         docsUrl: "https://developers.google.com/workspace",
-        capabilities: ["create_sheet", "create_doc", "read_sheet", "open_picker"],
+        capabilities: ["read_sheet", "open_picker"],
         suggestKeywords: [
             "google sheet",
             "google doc",
             "google slides",
-            "export to sheets",
-            "create a spreadsheet",
-            "create a doc",
+            "read spreadsheet",
+            "analyze sheet",
+            "open google file",
         ],
     },
 


### PR DESCRIPTION
## Summary

- Remove document creation operations (`create_doc`, `create_sheet`) from the Google Workspace Files integration
- Fix the infinite "Working" loop issue caused by malformed JSON tool calls when users requested document formatting

## Background

User Julianna tried to create a formatted PDF with specific fonts and logos. Carmenta attempted to use `google-workspace-files create_doc` but generated malformed JSON (`{"action", "create_doc"}` - comma instead of colon), causing infinite "Working" loops with no user feedback.

**Root cause**: The Docs API only supports plain text insertion - no formatting control. Users expected rich formatting but got malformed tool calls.

**Product decision**: Carmenta is NOT a document formatting service. The integration is now read-only: users select files via Google Picker, Carmenta reads/analyzes them.

## Changes

### Adapter (`lib/integrations/adapters/google-workspace-files.ts`)
- Removed `handleCreateSheet` and `handleCreateDoc` methods
- Added early detection for removed actions with helpful error message
- Updated `getHelp()` description and operations list

### Services (`lib/integrations/services.ts`)
- Updated description: "Read and analyze your Sheets, Docs, and Slides by selecting them via file picker"
- Updated capabilities: `["read_sheet", "open_picker"]`
- Updated keywords to focus on reading/analyzing

### Component (`components/tools/integrations/google-workspace-files.tsx`)
- Removed `FileCreatedConfirmation` component
- Updated header comment explaining the removal
- Simplified `renderOutput()` to only handle picker and read operations

### Knowledge (`knowledge/components/google-workspace-integration.md`)
- Added "Read-Only Integration (Decided 2025-01-18)" architecture decision
- Updated code examples to reflect current implementation
- Updated UX flows and milestones

## Available operations

| Operation | Description |
|-----------|-------------|
| `read_sheet` | Read data from a user-selected Google Sheet |
| `open_picker` | Open Google Picker for file selection |

## Test plan

- [x] TypeScript compiles without errors
- [x] ESLint passes (no errors in changed files)
- [x] All 2964 tests pass
- [ ] Manual test: Connect Google account, use `open_picker`, select a sheet, verify `read_sheet` works

Generated with Carmenta