### PR TITLE
🐛 Forward ChatErrorBoundary errors to Sentry

### DIFF
--- a/components/connection/chat.tsx
+++ b/components/connection/chat.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as Sentry from "@sentry/nextjs";
 import { Component, type ErrorInfo, type ReactNode } from "react";
 
 import { HoloThread } from "./holo-thread";
@@ -32,6 +33,13 @@ class ChatErrorBoundary extends Component<
         };
 
         logger.error(errorDetails, "Chat component error");
+
+        // Forward to Sentry - error boundaries swallow errors before they reach
+        // global handlers, so we must explicitly capture here
+        Sentry.captureException(error, {
+            extra: { componentStack: errorInfo.componentStack },
+            tags: { errorBoundary: "ChatErrorBoundary" },
+        });
     }
 
     render(): ReactNode {


### PR DESCRIPTION
## Summary
- ChatErrorBoundary was catching React errors and displaying fallback UI
- But it only logged to console, never forwarded to Sentry
- This caused client-side errors like `ReferenceError: _ref is not defined` to be invisible in error tracking

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Trigger an error in chat and verify it appears in Sentry

Generated with Carmenta